### PR TITLE
Add print and sound mapping

### DIFF
--- a/src/parser/mappers.ts
+++ b/src/parser/mappers.ts
@@ -66,6 +66,8 @@ import type {
   TextFormatting,
   SymbolFormatting,
   Harmony,
+  Print,
+  Sound,
   MeasureContent,
   PageLayout,
   SystemLayout,
@@ -150,6 +152,8 @@ import {
   LineWidthSchema,
   AppearanceSchema,
   SystemLayoutSchema,
+  PrintSchema,
+  SoundSchema,
 } from '../schemas';
 
 // Helper function to get text content of a child element
@@ -1006,6 +1010,44 @@ export const mapMeasureStyleElement = (element: Element): MeasureStyle | undefin
   }
 };
 
+// Function to map a <print> element
+export const mapPrintElement = (element: Element): Print => {
+  const printData: Partial<Print> = { _type: 'print' };
+  const newSystemAttr = getAttribute(element, 'new-system');
+  const newPageAttr = getAttribute(element, 'new-page');
+  const pageNumber = getAttribute(element, 'page-number');
+
+  if (newSystemAttr === 'yes' || newSystemAttr === 'no') {
+    printData.newSystem = newSystemAttr;
+  }
+  if (newPageAttr === 'yes' || newPageAttr === 'no') {
+    printData.newPage = newPageAttr;
+  }
+  if (pageNumber) {
+    printData.pageNumber = pageNumber;
+  }
+
+  return PrintSchema.parse(printData);
+};
+
+// Function to map a <sound> element
+export const mapSoundElement = (element: Element): Sound => {
+  const soundData: Partial<Sound> = { _type: 'sound' };
+  const tempoAttr = getAttribute(element, 'tempo');
+  const dynamicsAttr = getAttribute(element, 'dynamics');
+
+  if (tempoAttr) {
+    const tempo = parseFloat(tempoAttr);
+    if (!isNaN(tempo)) soundData.tempo = tempo;
+  }
+  if (dynamicsAttr) {
+    const dyn = parseFloat(dynamicsAttr);
+    if (!isNaN(dyn)) soundData.dynamics = dyn;
+  }
+
+  return SoundSchema.parse(soundData);
+};
+
 // Function to map an <attributes> element
 export const mapAttributesElement = (element: Element): Attributes => {
   const divisions = parseNumberContent(element, 'divisions');
@@ -1093,17 +1135,17 @@ export function mapMeasureElement(measureElement: Element): Measure {
         case 'harmony':
           mappedElement = mapHarmonyElement(childElement);
           break;
+        case 'print':
+          mappedElement = mapPrintElement(childElement);
+          break;
+        case 'sound':
+          mappedElement = mapSoundElement(childElement);
+          break;
         // case 'backup': // Example for future elements
         //   mappedElement = mapBackupElement(childElement);
         //   break;
         // case 'forward':
         //   mappedElement = mapForwardElement(childElement);
-        //   break;
-        // case 'print':
-        //   mappedElement = mapPrintElement(childElement);
-        //   break;
-        // case 'sound':
-        //   mappedElement = mapSoundElement(childElement);
         //   break;
       }
       if (mappedElement) {

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -31,3 +31,5 @@ export * from './unpitched';
 export * from './defaults';
 export * from './credit';
 export * from './harmony';
+export * from './print';
+export * from './sound';

--- a/src/schemas/measure.ts
+++ b/src/schemas/measure.ts
@@ -4,6 +4,8 @@ import { AttributesSchema } from './attributes';
 import { DirectionSchema } from './direction';
 import { BarlineSchema } from './barline';
 import { HarmonySchema } from './harmony';
+import { PrintSchema } from './print';
+import { SoundSchema } from './sound';
 // Import other implemented schemas that can be direct children of <measure>
 // For example, if ForwardSchema, BackupSchema are implemented, import them here.
 
@@ -15,9 +17,9 @@ export const MeasureContentSchema = z.union([
   DirectionSchema,
   BarlineSchema,
   HarmonySchema,
+  PrintSchema,
+  SoundSchema,
   // FiguredBassSchema, // Add when implemented
-  // PrintSchema,       // Add when implemented
-  // SoundSchema,       // Add when implemented
   // GroupingSchema,    // Add when implemented
   // LinkSchema,        // Add when implemented
   // BookmarkSchema,    // Add when implemented

--- a/src/schemas/print.ts
+++ b/src/schemas/print.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+import { PageLayoutSchema, SystemLayoutSchema, StaffLayoutSchema } from './defaults';
+import { YesNoEnum } from './common';
+
+export const PrintSchema = z.object({
+  _type: z.literal('print'),
+  pageLayout: PageLayoutSchema.optional(),
+  systemLayout: SystemLayoutSchema.optional(),
+  staffLayout: z.array(StaffLayoutSchema).optional(),
+  newSystem: YesNoEnum.optional(),
+  newPage: YesNoEnum.optional(),
+  pageNumber: z.string().optional(),
+});
+
+export type Print = z.infer<typeof PrintSchema>;

--- a/src/schemas/sound.ts
+++ b/src/schemas/sound.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const SoundSchema = z.object({
+  _type: z.literal('sound'),
+  tempo: z.number().optional(),
+  dynamics: z.number().optional(),
+});
+
+export type Sound = z.infer<typeof SoundSchema>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -72,6 +72,8 @@ export type {
   SymbolFormatting,
 } from '../schemas/credit';
 export type { Harmony } from '../schemas/harmony';
+export type { Print } from '../schemas/print';
+export type { Sound } from '../schemas/sound';
 export type { MeasureContent } from '../schemas/measure';
 // Add other inferred types from Zod schemas here as they are created.
 

--- a/tests/print-sound.test.ts
+++ b/tests/print-sound.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { mapMeasureElement } from '../src/parser/mappers';
+import type { Measure, Print, Sound } from '../src/types';
+import { JSDOM } from 'jsdom';
+
+function createElement(xmlString: string): Element {
+  const dom = new JSDOM(xmlString, { contentType: 'application/xml' });
+  const parsererror = dom.window.document.querySelector('parsererror');
+  if (parsererror) {
+    throw new Error(`Failed to parse XML string snippet: ${parsererror.textContent}`);
+  }
+  if (!dom.window.document.documentElement) {
+    throw new Error('No document element found in XML string snippet.');
+  }
+  return dom.window.document.documentElement;
+}
+
+describe('Measure print and sound parsing', () => {
+  it('should parse <print> and <sound> elements within a measure', () => {
+    const xml = `<measure number="1"><print new-system="yes" page-number="2"/><sound tempo="120"/></measure>`;
+    const element = createElement(xml);
+    const measure = mapMeasureElement(element);
+    expect(measure.content).toBeDefined();
+    const print = (measure.content?.[0] as Print);
+    const sound = (measure.content?.[1] as Sound);
+    expect(print._type).toBe('print');
+    expect(print.newSystem).toBe('yes');
+    expect(print.pageNumber).toBe('2');
+    expect(sound._type).toBe('sound');
+    expect(sound.tempo).toBe(120);
+  });
+});


### PR DESCRIPTION
## Summary
- add `PrintSchema` and `SoundSchema`
- export new schemas and types
- allow `<print>` and `<sound>` as measure content
- map `<print>` and `<sound>` elements in parser
- test parsing a measure containing print and sound

## Testing
- `npm test`