### PR TITLE
Enhance lyric parsing

### DIFF
--- a/src/parser/mappers.ts
+++ b/src/parser/mappers.ts
@@ -272,8 +272,25 @@ export const mapLyricElement = (element: Element): Lyric => {
   const lyricData: Partial<Lyric> = {
     text: getTextContent(element, 'text') ?? '',
     syllabic: getTextContent(element, 'syllabic') as 'single' | 'begin' | 'end' | 'middle' | undefined,
-    // TODO: Map other lyric attributes and child elements like number, name, extend, elision etc.
   };
+  const numberAttr = getAttribute(element, 'number');
+  const nameAttr = getAttribute(element, 'name');
+  if (numberAttr) lyricData.number = numberAttr;
+  if (nameAttr) lyricData.name = nameAttr;
+
+  const extendElement = element.querySelector('extend');
+  if (extendElement) {
+    lyricData.extend = {
+      type: getAttribute(extendElement, 'type') as 'start' | 'stop' | 'continue' | undefined,
+    };
+  }
+
+  const elisionElement = element.querySelector('elision');
+  if (elisionElement) {
+    lyricData.elision = {
+      text: elisionElement.textContent?.trim() || undefined,
+    };
+  }
   return LyricSchema.parse(lyricData);
 };
 

--- a/src/schemas/lyric.ts
+++ b/src/schemas/lyric.ts
@@ -1,9 +1,22 @@
 import { z } from 'zod';
 
+export const ExtendSchema = z.object({
+  type: z.enum(['start', 'stop', 'continue']).optional(),
+});
+export type Extend = z.infer<typeof ExtendSchema>;
+
+export const ElisionSchema = z.object({
+  text: z.string().optional(),
+});
+export type Elision = z.infer<typeof ElisionSchema>;
+
 export const LyricSchema = z.object({
   text: z.string(),
   syllabic: z.string().optional(), // common values: single, begin, end, middle
-  // Add other lyric attributes/elements like number, name, justify, placement, etc. if needed
+  number: z.string().optional(),
+  name: z.string().optional(),
+  extend: ExtendSchema.optional(),
+  elision: ElisionSchema.optional(),
 });
 
 export type Lyric = z.infer<typeof LyricSchema>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,7 +10,7 @@ export type { Key } from '../schemas/key';
 export type { Time } from '../schemas/time';
 export type { Clef } from '../schemas/clef';
 export type { Attributes } from '../schemas/attributes';
-export type { Lyric } from '../schemas/lyric';
+export type { Lyric, Extend, Elision } from '../schemas/lyric';
 export type { Tie } from '../schemas/tie';
 export type {
   Direction,

--- a/tests/note.test.ts
+++ b/tests/note.test.ts
@@ -65,6 +65,21 @@ describe('Note Schema Tests (note.mod)', () => {
       expect(lyric2.text).toBe('lo');
     });
 
+    it('should parse lyric attributes number, name, extend and elision', () => {
+      const xml = '<note><pitch><step>C</step><octave>4</octave></pitch><duration>4</duration><lyric number="1" name="verse"><syllabic>single</syllabic><text>la</text><extend type="start"/><elision>_</elision></lyric></note>';
+      const element = createElement(xml);
+      const note = mapNoteElement(element);
+      expect(note.lyrics).toBeDefined();
+      expect(note.lyrics).toHaveLength(1);
+      const lyric = note.lyrics?.[0] as Lyric;
+      expect(lyric.number).toBe('1');
+      expect(lyric.name).toBe('verse');
+      expect(lyric.extend).toBeDefined();
+      expect(lyric.extend?.type).toBe('start');
+      expect(lyric.elision).toBeDefined();
+      expect(lyric.elision?.text).toBe('_');
+    });
+
     it('should parse a <note> with <beam> elements', () => {
       const xml = '<note><pitch><step>A</step><octave>4</octave></pitch><duration>1</duration><type>16th</type><beam number="1">begin</beam><beam number="2">begin</beam></note>';
       const element = createElement(xml);


### PR DESCRIPTION
## Summary
- add schemas for lyric extend/elision
- expand LyricSchema with number, name, extend, elision
- export new lyric-related types
- map lyric attributes in parser
- cover lyric attributes in tests

## Testing
- `npm test`