### PR TITLE
Add more MusicXML notations

### DIFF
--- a/src/parser/mappers.ts
+++ b/src/parser/mappers.ts
@@ -38,6 +38,14 @@ import type {
   Articulations,
   Staccato,
   Accent,
+  Tenuto,
+  Spiccato,
+  Staccatissimo,
+  StrongAccent,
+  Tuplet,
+  Ornaments,
+  Technical,
+  Tie,
   Barline,
   BarStyle,
   Repeat,
@@ -114,6 +122,14 @@ import {
   ArticulationsSchema,
   StaccatoSchema,
   AccentSchema,
+  TenutoSchema,
+  SpiccatoSchema,
+  StaccatissimoSchema,
+  StrongAccentSchema,
+  TupletSchema,
+  OrnamentsSchema,
+  TechnicalSchema,
+  TieSchema,
   BarlineSchema,
   RepeatSchema,
   EndingSchema,
@@ -436,7 +452,10 @@ const mapSlurElement = (element: Element): Slur => {
 const mapArticulationsElement = (element: Element): Articulations => {
   const staccatoElement = element.querySelector('staccato');
   const accentElement = element.querySelector('accent');
-  // TODO: Query for other articulation types
+  const tenutoElement = element.querySelector('tenuto');
+  const spiccatoElement = element.querySelector('spiccato');
+  const staccatissimoElement = element.querySelector('staccatissimo');
+  const strongAccentElement = element.querySelector('strong-accent');
 
   const articulationsData: Partial<Articulations> = {
     placement: getAttribute(element, 'placement') as 'above' | 'below' | undefined,
@@ -448,9 +467,52 @@ const mapArticulationsElement = (element: Element): Articulations => {
   if (accentElement) {
     articulationsData.accent = {}; // AccentSchema is an empty object
   }
-  // TODO: Map other articulations
+  if (tenutoElement) {
+    articulationsData.tenuto = {};
+  }
+  if (spiccatoElement) {
+    articulationsData.spiccato = {};
+  }
+  if (staccatissimoElement) {
+    articulationsData.staccatissimo = {};
+  }
+  if (strongAccentElement) {
+    articulationsData.strongAccent = {};
+  }
 
   return ArticulationsSchema.parse(articulationsData);
+};
+
+// Helper to map a <tied> element
+const mapTiedElement = (element: Element): Tie => {
+  const type = getAttribute(element, 'type') as 'start' | 'stop' | undefined;
+  if (!type) {
+    throw new Error('<tied> element requires a "type" attribute.');
+  }
+  return TieSchema.parse({ type });
+};
+
+// Helper to map a <tuplet> element
+const mapTupletElement = (element: Element): Tuplet => {
+  const type = getAttribute(element, 'type') as 'start' | 'stop' | undefined;
+  if (!type) {
+    throw new Error('<tuplet> element requires a "type" attribute.');
+  }
+  const tupletData: Partial<Tuplet> = {
+    type,
+    number: parseOptionalNumberAttribute(element, 'number'),
+  };
+  return TupletSchema.parse(tupletData);
+};
+
+// Helper to map an <ornaments> element
+const mapOrnamentsElement = (_element: Element): Ornaments => {
+  return OrnamentsSchema.parse({});
+};
+
+// Helper to map a <technical> element
+const mapTechnicalElement = (_element: Element): Technical => {
+  return TechnicalSchema.parse({});
 };
 
 // Helper function to map a <words> element (within <direction-type>)
@@ -567,7 +629,10 @@ export const mapDirectionElement = (element: Element): Direction => {
 const mapNotationsElement = (element: Element): Notations => {
   const slurElements = Array.from(element.querySelectorAll('slur'));
   const articulationsElements = Array.from(element.querySelectorAll('articulations'));
-  // TODO: Query for other notation types like <tied>, <tuplet>, <ornaments>, <technical>
+  const tiedElements = Array.from(element.querySelectorAll('tied'));
+  const tupletElements = Array.from(element.querySelectorAll('tuplet'));
+  const ornamentsElements = Array.from(element.querySelectorAll('ornaments'));
+  const technicalElements = Array.from(element.querySelectorAll('technical'));
 
   const notationsData: Partial<Notations> = {};
 
@@ -576,6 +641,18 @@ const mapNotationsElement = (element: Element): Notations => {
   }
   if (articulationsElements.length > 0) {
     notationsData.articulations = articulationsElements.map(mapArticulationsElement);
+  }
+  if (tiedElements.length > 0) {
+    notationsData.tied = tiedElements.map(mapTiedElement);
+  }
+  if (tupletElements.length > 0) {
+    notationsData.tuplets = tupletElements.map(mapTupletElement);
+  }
+  if (ornamentsElements.length > 0) {
+    notationsData.ornaments = ornamentsElements.map(mapOrnamentsElement);
+  }
+  if (technicalElements.length > 0) {
+    notationsData.technical = technicalElements.map(mapTechnicalElement);
   }
 
   return NotationsSchema.parse(notationsData);

--- a/src/schemas/notations.ts
+++ b/src/schemas/notations.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { TieSchema } from './tie';
 
 /**
  * The slur element is used to represent slurs. Slurs can be nested.
@@ -23,7 +24,50 @@ export type Staccato = z.infer<typeof StaccatoSchema>;
 export const AccentSchema = z.object({}); // Empty element
 export type Accent = z.infer<typeof AccentSchema>;
 
-// TODO: Add schemas for other common articulations like tenuto, strong-accent, staccatissimo, spiccato, etc.
+/**
+ * Represents a tenuto articulation mark.
+ */
+export const TenutoSchema = z.object({});
+export type Tenuto = z.infer<typeof TenutoSchema>;
+
+/**
+ * Represents a spiccato articulation mark.
+ */
+export const SpiccatoSchema = z.object({});
+export type Spiccato = z.infer<typeof SpiccatoSchema>;
+
+/**
+ * Represents a staccatissimo articulation mark.
+ */
+export const StaccatissimoSchema = z.object({});
+export type Staccatissimo = z.infer<typeof StaccatissimoSchema>;
+
+/**
+ * Represents a strong-accent articulation mark.
+ */
+export const StrongAccentSchema = z.object({});
+export type StrongAccent = z.infer<typeof StrongAccentSchema>;
+
+/**
+ * The tuplet element represents tuplet notation.
+ */
+export const TupletSchema = z.object({
+  type: z.enum(['start', 'stop']),
+  number: z.number().int().optional(),
+});
+export type Tuplet = z.infer<typeof TupletSchema>;
+
+/**
+ * Placeholder schema for ornaments.
+ */
+export const OrnamentsSchema = z.object({});
+export type Ornaments = z.infer<typeof OrnamentsSchema>;
+
+/**
+ * Placeholder schema for technical notations.
+ */
+export const TechnicalSchema = z.object({});
+export type Technical = z.infer<typeof TechnicalSchema>;
 
 /**
  * The articulations element groups multiple articulation marks.
@@ -31,9 +75,10 @@ export type Accent = z.infer<typeof AccentSchema>;
 export const ArticulationsSchema = z.object({
   accent: AccentSchema.optional(),
   staccato: StaccatoSchema.optional(),
-  // Add other articulation elements here as optional fields
-  // tenuto: TenutoSchema.optional(),
-  // strongAccent: StrongAccentSchema.optional(), 
+  tenuto: TenutoSchema.optional(),
+  spiccato: SpiccatoSchema.optional(),
+  staccatissimo: StaccatissimoSchema.optional(),
+  strongAccent: StrongAccentSchema.optional(),
   placement: z.enum(['above', 'below']).optional(), // placement for the group
 });
 export type Articulations = z.infer<typeof ArticulationsSchema>;
@@ -45,6 +90,9 @@ export type Articulations = z.infer<typeof ArticulationsSchema>;
 export const NotationsSchema = z.object({
   slurs: z.array(SlurSchema).optional(),
   articulations: z.array(ArticulationsSchema).optional(), // MusicXML allows multiple <articulations> elements
-  // TODO: Add other notation types like <tied>, <tuplet>, <ornaments>, <technical>, <dynamics> (if not in <direction>)
+  tied: z.array(TieSchema).optional(),
+  tuplets: z.array(TupletSchema).optional(),
+  ornaments: z.array(OrnamentsSchema).optional(),
+  technical: z.array(TechnicalSchema).optional(),
 });
 export type Notations = z.infer<typeof NotationsSchema>; 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,6 +12,7 @@ export type { Clef } from '../schemas/clef';
 export type { Attributes } from '../schemas/attributes';
 export type { Lyric } from '../schemas/lyric';
 export type { Tie } from '../schemas/tie';
+export type { Tie as Tied } from '../schemas/tie';
 export type {
   Direction,
   DirectionType,
@@ -30,6 +31,13 @@ export type {
   Articulations,
   Staccato,
   Accent,
+  Tenuto,
+  Spiccato,
+  Staccatissimo,
+  StrongAccent,
+  Tuplet,
+  Ornaments,
+  Technical,
 } from '../schemas/notations';
 export type { Barline, BarStyle, Repeat, Ending } from '../schemas/barline';
 export type { Work } from '../schemas/work';

--- a/tests/note.test.ts
+++ b/tests/note.test.ts
@@ -135,6 +135,28 @@ describe('Note Schema Tests (note.mod)', () => {
       expect(note.printLeger).toBe('no');
     });
 
+    it('maps articulations like tenuto and spiccato', () => {
+      const xml = '<note><pitch><step>C</step><octave>4</octave></pitch><duration>1</duration><notations><articulations placement="above"><tenuto/><spiccato/></articulations></notations></note>';
+      const element = createElement(xml);
+      const note = mapNoteElement(element);
+      expect(note.notations?.articulations).toBeDefined();
+      const arts = note.notations?.articulations?.[0];
+      expect(arts?.tenuto).toBeDefined();
+      expect(arts?.spiccato).toBeDefined();
+      expect(arts?.placement).toBe('above');
+    });
+
+    it('maps tied, tuplet, ornaments and technical elements', () => {
+      const xml = '<note><pitch><step>D</step><octave>4</octave></pitch><duration>2</duration><notations><tied type="start"/><tuplet type="start" number="3"/><ornaments/><technical/></notations></note>';
+      const element = createElement(xml);
+      const note = mapNoteElement(element);
+      expect(note.notations?.tied).toHaveLength(1);
+      expect(note.notations?.tuplets).toHaveLength(1);
+      expect(note.notations?.ornaments).toHaveLength(1);
+      expect(note.notations?.technical).toHaveLength(1);
+      expect(note.notations?.tuplets?.[0].number).toBe(3);
+    });
+
     // TODO: Add tests for tie, time-modification, notations (articulations, ornaments, technical), etc.
   });
 }); 


### PR DESCRIPTION
## Summary
- expand notations schema with more articulations and notation elements
- support new notation parsing in mappers
- exercise new mappings in note tests

## Testing
- `npm test`