### PR TITLE
Add coda, segno and fermata parsing

### DIFF
--- a/src/parser/mappers.ts
+++ b/src/parser/mappers.ts
@@ -42,6 +42,7 @@ import type {
   BarStyle,
   Repeat,
   Ending,
+  Fermata,
   Work,
   Identification,
   Creator,
@@ -117,6 +118,7 @@ import {
   BarlineSchema,
   RepeatSchema,
   EndingSchema,
+  FermataSchema,
   WorkSchema,
   IdentificationSchema,
   CreatorSchema,
@@ -432,6 +434,15 @@ const mapSlurElement = (element: Element): Slur => {
   return SlurSchema.parse(slurData);
 };
 
+const mapFermataElement = (element: Element) => {
+  const fermataData: Partial<Fermata> = {};
+  const text = element.textContent?.trim();
+  if (text) fermataData.value = text as any;
+  const typeAttr = getAttribute(element, 'type');
+  if (typeAttr) fermataData.type = typeAttr as 'upright' | 'inverted';
+  return FermataSchema.parse(fermataData);
+};
+
 // Helper function to map an <articulations> element
 const mapArticulationsElement = (element: Element): Articulations => {
   const staccatoElement = element.querySelector('staccato');
@@ -618,6 +629,7 @@ export const mapBarlineElement = (element: Element): Barline => {
   const endingElement = element.querySelector('ending');
   const codaElement = element.querySelector('coda');
   const segnoElement = element.querySelector('segno');
+  const fermataElements = Array.from(element.querySelectorAll('fermata'));
 
   const barlineData: Partial<Barline> = {
     _type: 'barline',
@@ -639,6 +651,18 @@ export const mapBarlineElement = (element: Element): Barline => {
   if (segnoElement) {
     barlineData.segno = {};
   }
+  if (fermataElements.length > 0) {
+    barlineData.fermata = fermataElements.map(mapFermataElement);
+  }
+  barlineData.segnoAttr = getAttribute(element, 'segno');
+  barlineData.codaAttr = getAttribute(element, 'coda');
+  const divisionsAttr = getAttribute(element, 'divisions');
+  if (divisionsAttr) {
+    const val = parseInt(divisionsAttr, 10);
+    if (!isNaN(val)) barlineData.divisions = val;
+  }
+  const idAttr = getAttribute(element, 'id');
+  if (idAttr) barlineData.id = idAttr;
   // TODO: Parse other barline children and attributes
 
   return BarlineSchema.parse(barlineData);

--- a/src/schemas/barline.ts
+++ b/src/schemas/barline.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { FermataSchema } from './fermata';
 
 /**
  * The bar-style simple type represents the graphic appearance of a barline.
@@ -68,7 +69,17 @@ export const BarlineSchema = z.object({
    * This is an empty element in MusicXML.
    */
   segno: z.object({}).optional(),
-  // TODO: Add other barline children like <fermata>, <divisions> (for swing section changes)
-  // TODO: Add attributes like `implicit`
+  /**
+   * Optional fermata markings that appear with the barline. Up to two are allowed.
+   */
+  fermata: z.array(FermataSchema).optional(),
+  /** Segno attribute for playback when a segno child is present. */
+  segnoAttr: z.string().optional(),
+  /** Coda attribute for playback when a coda child is present. */
+  codaAttr: z.string().optional(),
+  /** Divisions attribute used with segno or coda jumps. */
+  divisions: z.number().optional(),
+  /** Optional unique ID value. */
+  id: z.string().optional(),
 });
 export type Barline = z.infer<typeof BarlineSchema>; 

--- a/src/schemas/fermata.ts
+++ b/src/schemas/fermata.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+
+export const FermataShapeEnum = z.enum([
+  'normal',
+  'angled',
+  'square',
+  'double-angled',
+  'double-square',
+  'double-dot',
+  'half-curve',
+  'curlew',
+  '',
+]);
+export type FermataShape = z.infer<typeof FermataShapeEnum>;
+
+export const FermataSchema = z.object({
+  value: FermataShapeEnum.optional(),
+  type: z.enum(['upright', 'inverted']).optional(),
+});
+export type Fermata = z.infer<typeof FermataSchema>;

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -35,3 +35,4 @@ export * from './backup';
 export * from './forward';
 export * from './print';
 export * from './sound';
+export * from './fermata';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -32,6 +32,7 @@ export type {
   Accent,
 } from '../schemas/notations';
 export type { Barline, BarStyle, Repeat, Ending } from '../schemas/barline';
+export type { Fermata, FermataShape } from '../schemas/fermata';
 export type { Work } from '../schemas/work';
 export type {
   Identification,

--- a/tests/barline.test.ts
+++ b/tests/barline.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { mapBarlineElement } from '../src/parser/mappers';
-import type { Barline, Repeat, Ending } from '../src/types';
+import type { Barline, Repeat, Ending, Fermata } from '../src/types';
 import { JSDOM } from 'jsdom';
 
 // Helper to create an Element from an XML string snippet
@@ -77,6 +77,34 @@ describe('Barline Schema Tests', () => {
       expect(barline.barStyle).toBe('dotted');
     });
     
-    // TODO: Add tests for coda, segno, fermata within barline if applicable via mapBarlineElement
+    it('should parse coda and segno child elements', () => {
+      const xml = `<barline><coda/><segno/></barline>`;
+      const element = createElement(xml);
+      const barline = mapBarlineElement(element);
+      expect(barline.coda).toBeDefined();
+      expect(barline.segno).toBeDefined();
+    });
+
+    it('should parse fermata elements', () => {
+      const xml = `<barline><fermata type="upright">angled</fermata><fermata type="inverted"/></barline>`;
+      const element = createElement(xml);
+      const barline = mapBarlineElement(element);
+      expect(barline.fermata).toBeDefined();
+      const fermatas = barline.fermata as Fermata[];
+      expect(fermatas.length).toBe(2);
+      expect(fermatas[0].value).toBe('angled');
+      expect(fermatas[0].type).toBe('upright');
+      expect(fermatas[1].type).toBe('inverted');
+    });
+
+    it('should parse barline attributes segno, coda and divisions', () => {
+      const xml = `<barline segno="S1" coda="C1" divisions="480" id="b1"/>`;
+      const element = createElement(xml);
+      const barline = mapBarlineElement(element);
+      expect(barline.segnoAttr).toBe('S1');
+      expect(barline.codaAttr).toBe('C1');
+      expect(barline.divisions).toBe(480);
+      expect(barline.id).toBe('b1');
+    });
   });
 }); 


### PR DESCRIPTION
## Summary
- add Fermata schema and export it
- extend Barline schema with fermata and playback attributes
- parse new barline children and attributes
- test parsing of coda, segno, fermata, and barline attributes

## Testing
- `npm test`