### PR TITLE
Add parsing for line-detail and staff-tuning

### DIFF
--- a/src/schemas/staffDetails.ts
+++ b/src/schemas/staffDetails.ts
@@ -6,9 +6,23 @@ import { YesNoEnum } from './common';
  * This includes the number of staff lines and other details.
  */
 
-// Placeholder for complex types that might need their own schemas
-export const StaffTuningSchema = z.object({}); // Define later if needed
-export const LineDetailSchema = z.object({}); // Define later if needed
+// Schema for <line-detail> element
+// Only a subset of attributes are modeled for now.
+export const LineDetailSchema = z.object({
+  line: z.number().int(),
+  width: z.number().optional(),
+  color: z.string().optional(),
+  lineType: z.string().optional(),
+  printObject: YesNoEnum.optional(),
+});
+
+// Schema for <staff-tuning> element
+export const StaffTuningSchema = z.object({
+  tuningStep: z.enum(['A', 'B', 'C', 'D', 'E', 'F', 'G']),
+  tuningAlter: z.number().optional(),
+  tuningOctave: z.number().int(),
+  line: z.number().int(),
+});
 
 export const StaffDetailsSchema = z.object({
   /**

--- a/tests/attributes.test.ts
+++ b/tests/attributes.test.ts
@@ -92,7 +92,39 @@ describe('Attributes Schema Tests', () => {
       expect(attributes.staves).toBe(2);
     });
 
-    // TODO: Add tests for part-symbol, instruments, staff-details, transpose, measure-style
+    // TODO: Add tests for part-symbol and instruments
+
+    it('should parse <staff-details> with <line-detail>', () => {
+      const xml = `<attributes><staff-details><staff-lines>5</staff-lines><line-detail line="1" width="0.5" color="#ff0" line-type="dashed" print-object="no"/></staff-details></attributes>`;
+      const element = createElement(xml);
+      const attributes = mapAttributesElement(element);
+      expect(attributes.staffDetails).toBeDefined();
+      expect(attributes.staffDetails).toHaveLength(1);
+      const sd = attributes.staffDetails?.[0]!;
+      expect(sd.lineDetail).toBeDefined();
+      expect(sd.lineDetail).toHaveLength(1);
+      const ld = sd.lineDetail?.[0]!;
+      expect(ld.line).toBe(1);
+      expect(ld.width).toBeCloseTo(0.5);
+      expect(ld.color).toBe('#ff0');
+      expect(ld.lineType).toBe('dashed');
+      expect(ld.printObject).toBe('no');
+    });
+
+    it('should parse <staff-details> with <staff-tuning>', () => {
+      const xml = `<attributes><staff-details><staff-tuning line="1"><tuning-step>E</tuning-step><tuning-octave>4</tuning-octave></staff-tuning></staff-details></attributes>`;
+      const element = createElement(xml);
+      const attributes = mapAttributesElement(element);
+      expect(attributes.staffDetails).toBeDefined();
+      expect(attributes.staffDetails).toHaveLength(1);
+      const sd = attributes.staffDetails?.[0]!;
+      expect(sd.staffTuning).toBeDefined();
+      expect(sd.staffTuning).toHaveLength(1);
+      const tuning = sd.staffTuning?.[0]!;
+      expect(tuning.line).toBe(1);
+      expect(tuning.tuningStep).toBe('E');
+      expect(tuning.tuningOctave).toBe(4);
+    });
 
     it('should parse <measure-style> with <multiple-rest>', () => {
       const xml = `<attributes><measure-style><multiple-rest use-symbols="yes">4</multiple-rest></measure-style></attributes>`;


### PR DESCRIPTION
## Summary
- support `<line-detail>` and `<staff-tuning>` in staff details
- validate these new elements with zod schemas
- test parsing of new staff details

## Testing
- `npm test`