### PR TITLE
Add staff-layout parsing support

### DIFF
--- a/src/parser/mappers.ts
+++ b/src/parser/mappers.ts
@@ -73,6 +73,7 @@ import type {
   MeasureContent,
   PageLayout,
   SystemLayout,
+  StaffLayout,
   Margins,
   LineWidth,
   Appearance,
@@ -154,6 +155,7 @@ import {
   LineWidthSchema,
   AppearanceSchema,
   SystemLayoutSchema,
+  StaffLayoutSchema,
   BackupSchema,
   ForwardSchema,
   PrintSchema,
@@ -1328,6 +1330,25 @@ const mapSystemLayoutElement = (element: Element): SystemLayout | undefined => {
   }
 };
 
+// Helper to parse <staff-layout> element
+const mapStaffLayoutElement = (element: Element): StaffLayout | undefined => {
+  if (!element) return undefined;
+  const staffLayoutData: Partial<StaffLayout> = {
+    number: parseOptionalNumberAttribute(element, 'number'),
+    staffDistance: parseFloatContent(element, 'staff-distance'),
+  };
+  Object.keys(staffLayoutData).forEach(
+    key => staffLayoutData[key as keyof StaffLayout] === undefined && delete staffLayoutData[key as keyof StaffLayout],
+  );
+  if (Object.keys(staffLayoutData).length === 0) return undefined;
+  try {
+    return StaffLayoutSchema.parse(staffLayoutData);
+  } catch (e) {
+    // console.warn('Failed to parse staff-layout element:', JSON.stringify(staffLayoutData, null, 2), (e as z.ZodError).errors);
+    return undefined;
+  }
+};
+
 // Helper to parse <line-width> element
 const mapLineWidthElement = (element: Element): LineWidth | undefined => {
   if (!element) return undefined;
@@ -1421,7 +1442,7 @@ export const mapDefaultsElement = (element: Element): Defaults | undefined => {
   const wordFontElement = element.querySelector('word-font');
   const lyricFontElements = Array.from(element.querySelectorAll('lyric-font'));
   const lyricLanguageElements = Array.from(element.querySelectorAll('lyric-language'));
-  // TODO: Add staff-layout mapping if needed
+  const staffLayoutElements = Array.from(element.querySelectorAll('staff-layout'));
 
   const defaultsData: Partial<Defaults> = {};
 
@@ -1439,6 +1460,12 @@ export const mapDefaultsElement = (element: Element): Defaults | undefined => {
   if (systemLayoutElement) { // Added
     const mappedSystemLayout = mapSystemLayoutElement(systemLayoutElement);
     if (mappedSystemLayout) defaultsData.systemLayout = mappedSystemLayout;
+  }
+  if (staffLayoutElements.length > 0) {
+    const mappedStaffLayouts = staffLayoutElements
+      .map(mapStaffLayoutElement)
+      .filter(Boolean) as StaffLayout[];
+    if (mappedStaffLayouts.length > 0) defaultsData.staffLayout = mappedStaffLayouts;
   }
   if (appearanceElement) { // Added
     const mappedAppearance = mapAppearanceElement(appearanceElement);

--- a/src/schemas/defaults.ts
+++ b/src/schemas/defaults.ts
@@ -16,9 +16,13 @@ export const SystemLayoutSchema = z.object({
   systemDistance: z.number().optional(),
   topSystemDistance: z.number().optional(),
 }); 
-export const StaffLayoutSchema = z.object({ // TODO: Define staff layout details
-  staffDistance: z.number().optional(), // Example from layout.mod
-}); 
+export const StaffLayoutSchema = z.object({
+  /** Optional staff number this layout applies to. Staves are numbered from top
+   *  to bottom starting at 1. */
+  number: z.number().int().optional(),
+  /** Distance from the previous staff in tenths. */
+  staffDistance: z.number().optional(),
+});
 export const AppearanceSchema = z.object({
   lineWidths: z.array(LineWidthSchema).optional(),
 }); 

--- a/tests/xmlsamples.test.ts
+++ b/tests/xmlsamples.test.ts
@@ -71,4 +71,13 @@ describe('Specific feature checks from samples', () => {
     const noteWithStaccato = score.parts[0].measures.flatMap(m => getNotesFromContent(m.content)).find(n => n.notations?.articulations?.some(a => a.staccato));
     expect(noteWithStaccato).toBeDefined();
   });
+
+  it('ActorPreludeSample.musicxml captures staff-layout defaults', () => {
+    const xmlString = fs.readFileSync(path.join(samplesDir, 'ActorPreludeSample.musicxml'), 'utf-8');
+    const xmlDoc = parseMusicXmlString(xmlString);
+    if (!xmlDoc) throw new Error('ActorPreludeSample.musicxml failed to parse');
+    const score = mapDocumentToScorePartwise(xmlDoc);
+    expect(score.defaults?.staffLayout).toBeDefined();
+    expect(score.defaults?.staffLayout?.[0]?.staffDistance).toBe(93);
+  });
 });


### PR DESCRIPTION
## Summary
- flesh out StaffLayoutSchema with `number` and `staffDistance`
- parse `<staff-layout>` elements in defaults
- test that staff-layout defaults are captured from sample XML

## Testing
- `npm test`