### PR TITLE
Add relation and miscellaneous parsing

### DIFF
--- a/reference/identification/IdentificationWithExtras.musicxml
+++ b/reference/identification/IdentificationWithExtras.musicxml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <identification>
+    <creator type="composer">Test Composer</creator>
+    <encoding>
+      <software>Test Software</software>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="no" attribute="color" value="red"/>
+    </encoding>
+    <relation type="music">Original Source</relation>
+    <relation type="arrangement">Arrangement of Source</relation>
+    <miscellaneous>
+      <miscellaneous-field name="source">Library</miscellaneous-field>
+      <miscellaneous-field name="comment">Test field</miscellaneous-field>
+    </miscellaneous>
+  </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Music</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1</duration>
+        <type>quarter</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/src/schemas/identification.ts
+++ b/src/schemas/identification.ts
@@ -27,11 +27,36 @@ export const EncodingSoftwareSchema = z.string(); // Software name
 export const EncodingDateSchema = z.string(); // Date in YYYY-MM-DD format or similar
 export const EncoderSchema = z.string(); // Person or organization doing the encoding
 
+export const SupportsSchema = z.object({
+  type: z.enum(['yes', 'no']),
+  element: z.string(),
+  attribute: z.string().optional(),
+  value: z.string().optional(),
+});
+export type Supports = z.infer<typeof SupportsSchema>;
+
+export const RelationSchema = z.object({
+  type: z.string().optional(),
+  text: z.string(),
+});
+export type Relation = z.infer<typeof RelationSchema>;
+
+export const MiscellaneousFieldSchema = z.object({
+  name: z.string(),
+  text: z.string(),
+});
+export type MiscellaneousField = z.infer<typeof MiscellaneousFieldSchema>;
+
+export const MiscellaneousSchema = z.object({
+  fields: z.array(MiscellaneousFieldSchema),
+});
+export type Miscellaneous = z.infer<typeof MiscellaneousSchema>;
+
 export const EncodingSchema = z.object({
   software: z.array(EncodingSoftwareSchema).optional(), // Can have multiple <software> tags
   'encoding-date': z.array(EncodingDateSchema).optional(), // Can have multiple <encoding-date> tags
   encoder: z.array(EncoderSchema).optional(), // Can have multiple <encoder> tags
-  // TODO: Add other encoding children like <supports>
+  supports: z.array(SupportsSchema).optional(),
 });
 export type Encoding = z.infer<typeof EncodingSchema>;
 
@@ -47,6 +72,8 @@ export const IdentificationSchema = z.object({
    * The source element is used to give a bibliographic reference for the source of the music.
    */
   source: z.string().optional(),
-  // TODO: Add other identification children like <relation>, <miscellaneous>
+  relations: z.array(RelationSchema).optional(),
+  miscellaneous: MiscellaneousSchema.optional(),
 });
-export type Identification = z.infer<typeof IdentificationSchema>; 
+export type Identification = z.infer<typeof IdentificationSchema>;
+

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -38,6 +38,10 @@ export type {
   Creator,
   Rights,
   Encoding,
+  Supports,
+  Relation,
+  Miscellaneous,
+  MiscellaneousField,
   EncodingSoftwareSchema as EncodingSoftware,
   EncodingDateSchema as EncodingDate,
   EncoderSchema as Encoder

--- a/tests/identification.test.ts
+++ b/tests/identification.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { parseMusicXmlString } from '../src/parser/xmlParser';
+import { mapDocumentToScorePartwise } from '../src/parser/mappers';
+import type { Supports, Relation, Miscellaneous, MiscellaneousField } from '../src/types';
+
+const filePath = path.resolve(__dirname, '../reference/identification/IdentificationWithExtras.musicxml');
+
+describe('Identification extras parsing', () => {
+  it('maps supports, relation, and miscellaneous elements', () => {
+    const xmlString = fs.readFileSync(filePath, 'utf-8');
+    const xmlDoc = parseMusicXmlString(xmlString);
+    if (!xmlDoc) throw new Error('failed to parse xml');
+    const score = mapDocumentToScorePartwise(xmlDoc);
+    const id = score.identification;
+    expect(id).toBeDefined();
+    expect(id?.encoding?.supports?.length).toBe(2);
+    const supports = id?.encoding?.supports as Supports[];
+    expect(supports[0].element).toBe('accidental');
+    expect(supports[0].type).toBe('yes');
+    expect(supports[1].attribute).toBe('color');
+
+    expect(id?.relations?.length).toBe(2);
+    const relations = id?.relations as Relation[];
+    expect(relations[0].text).toBe('Original Source');
+    expect(relations[0].type).toBe('music');
+
+    expect(id?.miscellaneous).toBeDefined();
+    const misc = id?.miscellaneous as Miscellaneous;
+    expect(misc.fields.length).toBe(2);
+    const fieldNames = misc.fields.map(f => f.name);
+    expect(fieldNames).toContain('comment');
+  });
+});


### PR DESCRIPTION
## Summary
- expand identification schema with supports, relation, and miscellaneous elements
- map new identification structures in parser
- provide new reference MusicXML with these tags
- test parsing of supports, relation, and miscellaneous

## Testing
- `npm test`