### PR TITLE
Add tests for ornaments and other mappings

### DIFF
--- a/src/schemas/notations.ts
+++ b/src/schemas/notations.ts
@@ -33,10 +33,27 @@ export const ArticulationsSchema = z.object({
   staccato: StaccatoSchema.optional(),
   // Add other articulation elements here as optional fields
   // tenuto: TenutoSchema.optional(),
-  // strongAccent: StrongAccentSchema.optional(), 
+  // strongAccent: StrongAccentSchema.optional(),
   placement: z.enum(['above', 'below']).optional(), // placement for the group
 });
 export type Articulations = z.infer<typeof ArticulationsSchema>;
+
+export const TrillMarkSchema = z.object({
+  placement: z.enum(['above', 'below']).optional(),
+});
+export type TrillMark = z.infer<typeof TrillMarkSchema>;
+
+export const TremoloSchema = z.object({
+  value: z.number().int().optional(),
+  type: z.enum(['single', 'start', 'stop']).optional(),
+});
+export type Tremolo = z.infer<typeof TremoloSchema>;
+
+export const OrnamentsSchema = z.object({
+  trillMark: z.array(TrillMarkSchema).optional(),
+  tremolo: z.array(TremoloSchema).optional(),
+});
+export type Ornaments = z.infer<typeof OrnamentsSchema>;
 
 /**
  * The notations element groups musical notations that are not related to pitch or duration.
@@ -45,6 +62,7 @@ export type Articulations = z.infer<typeof ArticulationsSchema>;
 export const NotationsSchema = z.object({
   slurs: z.array(SlurSchema).optional(),
   articulations: z.array(ArticulationsSchema).optional(), // MusicXML allows multiple <articulations> elements
+  ornaments: OrnamentsSchema.optional(),
   // TODO: Add other notation types like <tied>, <tuplet>, <ornaments>, <technical>, <dynamics> (if not in <direction>)
 });
 export type Notations = z.infer<typeof NotationsSchema>; 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,6 +30,9 @@ export type {
   Articulations,
   Staccato,
   Accent,
+  Ornaments,
+  TrillMark,
+  Tremolo,
 } from '../schemas/notations';
 export type { Barline, BarStyle, Repeat, Ending } from '../schemas/barline';
 export type { Work } from '../schemas/work';

--- a/tests/attributes.test.ts
+++ b/tests/attributes.test.ts
@@ -92,6 +92,44 @@ describe('Attributes Schema Tests', () => {
       expect(attributes.staves).toBe(2);
     });
 
+    it('should parse <part-symbol> within attributes', () => {
+      const xml = `<attributes><part-symbol group-symbol="brace" top-staff="1" bottom-staff="2">brace</part-symbol></attributes>`;
+      const element = createElement(xml);
+      const attributes = mapAttributesElement(element);
+      expect(attributes.partSymbol).toBeDefined();
+      expect(attributes.partSymbol?.value).toBe('brace');
+      expect(attributes.partSymbol?.groupSymbol).toBe('brace');
+      expect(attributes.partSymbol?.topStaff).toBe(1);
+      expect(attributes.partSymbol?.bottomStaff).toBe(2);
+    });
+
+    it('should parse <transpose> within attributes', () => {
+      const xml = `<attributes><transpose number="1"><chromatic>-3</chromatic><diatonic>-2</diatonic><octave-change>-1</octave-change></transpose></attributes>`;
+      const element = createElement(xml);
+      const attributes = mapAttributesElement(element);
+      expect(attributes.transpose).toBeDefined();
+      const transpose = attributes.transpose!;
+      expect(transpose.chromatic).toBe(-3);
+      expect(transpose.diatonic).toBe(-2);
+      expect(transpose.octaveChange).toBe(-1);
+      expect(transpose.number).toBe(1);
+    });
+
+    it('should parse <staff-details> within attributes', () => {
+      const xml = `<attributes><staff-details number="1" print-object="yes"><staff-lines>5</staff-lines><capo>2</capo><staff-size scaling="1.2">100</staff-size></staff-details></attributes>`;
+      const element = createElement(xml);
+      const attributes = mapAttributesElement(element);
+      expect(attributes.staffDetails).toBeDefined();
+      expect(attributes.staffDetails).toHaveLength(1);
+      const sd = attributes.staffDetails![0];
+      expect(sd.number).toBe(1);
+      expect(sd.staffLines).toBe(5);
+      expect(sd.capo).toBe(2);
+      expect(sd.staffSize?.value).toBe(100);
+      expect(sd.staffSize?.scaling).toBe(1.2);
+      expect(sd.printObject).toBe('yes');
+    });
+
     // TODO: Add tests for part-symbol, instruments, staff-details, transpose, measure-style
 
     it('should parse <measure-style> with <multiple-rest>', () => {

--- a/tests/barline.test.ts
+++ b/tests/barline.test.ts
@@ -76,6 +76,20 @@ describe('Barline Schema Tests', () => {
       expect(barline.location).toBe('middle');
       expect(barline.barStyle).toBe('dotted');
     });
+
+    it('should parse coda mark in <barline>', () => {
+      const xml = `<barline><coda/></barline>`;
+      const element = createElement(xml);
+      const barline = mapBarlineElement(element);
+      expect(barline.coda).toBeDefined();
+    });
+
+    it('should parse segno mark in <barline>', () => {
+      const xml = `<barline><segno/></barline>`;
+      const element = createElement(xml);
+      const barline = mapBarlineElement(element);
+      expect(barline.segno).toBeDefined();
+    });
     
     // TODO: Add tests for coda, segno, fermata within barline if applicable via mapBarlineElement
   });

--- a/tests/note.test.ts
+++ b/tests/note.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { mapNoteElement } from '../src/parser/mappers';
-import type { Note, Pitch, Rest, Lyric, Beam, Slur } from '../src/types'; // Added more types as needed
+import type { Note, Pitch, Rest, Lyric, Beam, Slur, Ornaments } from '../src/types';
 import { JSDOM } from 'jsdom';
 
 // Helper to create an Element from an XML string snippet
@@ -133,6 +133,27 @@ describe('Note Schema Tests (note.mod)', () => {
       const element = createElement(xml);
       const note = mapNoteElement(element);
       expect(note.printLeger).toBe('no');
+    });
+
+    it('should parse <tie> elements on a note', () => {
+      const xml = '<note><pitch><step>A</step><octave>4</octave></pitch><duration>4</duration><tie type="start"/><tie type="stop"/></note>';
+      const element = createElement(xml);
+      const note = mapNoteElement(element);
+      expect(note.ties).toBeDefined();
+      expect(note.ties).toHaveLength(2);
+      expect(note.ties?.[0].type).toBe('start');
+      expect(note.ties?.[1].type).toBe('stop');
+    });
+
+    it('should parse ornaments inside <notations>', () => {
+      const xml = '<note><pitch><step>B</step><octave>4</octave></pitch><duration>2</duration><notations><ornaments><trill-mark placement="above"/><tremolo type="single">3</tremolo></ornaments></notations></note>';
+      const element = createElement(xml);
+      const note = mapNoteElement(element);
+      expect(note.notations?.ornaments).toBeDefined();
+      const ornaments = note.notations?.ornaments as Ornaments;
+      expect(ornaments.trillMark?.[0].placement).toBe('above');
+      expect(ornaments.tremolo?.[0].type).toBe('single');
+      expect(ornaments.tremolo?.[0].value).toBe(3);
     });
 
     // TODO: Add tests for tie, time-modification, notations (articulations, ornaments, technical), etc.


### PR DESCRIPTION
## Summary
- support ornaments mapping in notations
- expose ornament types
- test part-symbol, transpose and staff-details
- test coda and segno barlines
- test ties and ornaments in note mapping

## Testing
- `npm test`