### PR TITLE
Implement credit symbol parsing

### DIFF
--- a/src/parser/mappers.ts
+++ b/src/parser/mappers.ts
@@ -2320,7 +2320,41 @@ export const mapCreditWordsElement = (
 export const mapCreditSymbolElement = (
   element: Element,
 ): CreditSymbol | undefined => {
-  return undefined; // Add this line to satisfy the return type
+  const smuflGlyphName = element.textContent?.trim() ?? "";
+
+  const formatting: Partial<SymbolFormatting> = {};
+  const dx = parseOptionalNumberAttribute(element, "default-x");
+  if (dx !== undefined) formatting.defaultX = dx;
+  const dy = parseOptionalNumberAttribute(element, "default-y");
+  if (dy !== undefined) formatting.defaultY = dy;
+  const haAttr = getAttribute(element, "halign");
+  if (haAttr && ["left", "center", "right"].includes(haAttr)) {
+    formatting.halign = haAttr as "left" | "center" | "right";
+  }
+  const vaAttr = getAttribute(element, "valign");
+  if (vaAttr && ["top", "middle", "bottom"].includes(vaAttr)) {
+    formatting.valign = vaAttr as "top" | "middle" | "bottom";
+  }
+
+  const data: Partial<CreditSymbol> = { smuflGlyphName };
+  if (Object.keys(formatting).length > 0) {
+    data.formatting = formatting as SymbolFormatting;
+  }
+
+  if (
+    data.smuflGlyphName === "" &&
+    Object.keys(formatting).length === 0 &&
+    !element.hasAttributes()
+  ) {
+    return undefined;
+  }
+
+  try {
+    return CreditSymbolSchema.parse(data);
+  } catch (e) {
+    // console.warn('CreditSymbol parse error', data, (e as z.ZodError).errors);
+    return undefined;
+  }
 };
 
 export function mapRootElement(

--- a/tests/credit.test.ts
+++ b/tests/credit.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { mapCreditElement } from '../src/parser/mappers';
+import type { CreditSymbol } from '../src/types';
+
+function createElement(xmlString: string): Element {
+  const dom = new JSDOM(xmlString, { contentType: 'application/xml' });
+  const parsererror = dom.window.document.querySelector('parsererror');
+  if (parsererror) {
+    throw new Error(`Failed to parse XML string snippet: ${parsererror.textContent}`);
+  }
+  if (!dom.window.document.documentElement) {
+    throw new Error('No document element found in XML string snippet.');
+  }
+  return dom.window.document.documentElement;
+}
+
+describe('Credit parsing', () => {
+  it('parses credit-symbol inside credit', () => {
+    const xml = `<credit page="1"><credit-type>title</credit-type><credit-symbol default-x="10" default-y="20" halign="center" valign="top">gClef</credit-symbol></credit>`;
+    const element = createElement(xml);
+    const credit = mapCreditElement(element)!;
+    expect(credit).toBeDefined();
+    expect(credit.creditSymbols).toBeDefined();
+    expect(credit.creditSymbols?.length).toBe(1);
+    const symbol = credit.creditSymbols?.[0] as CreditSymbol;
+    expect(symbol.smuflGlyphName).toBe('gClef');
+    expect(symbol.formatting?.defaultX).toBe(10);
+    expect(symbol.formatting?.defaultY).toBe(20);
+    expect(symbol.formatting?.halign).toBe('center');
+    expect(symbol.formatting?.valign).toBe('top');
+  });
+});


### PR DESCRIPTION
## Summary
- parse `<credit-symbol>` elements and validate with `CreditSymbolSchema`
- test credit symbol parsing

## Testing
- `npm test`