### PR TITLE
Add Sound attribute support

### DIFF
--- a/src/parser/mappers/noteMeasureMappers.ts
+++ b/src/parser/mappers/noteMeasureMappers.ts
@@ -1635,6 +1635,22 @@ export const mapSoundElement = (element: Element): Sound => {
   const soundData: Partial<Sound> = { _type: "sound" };
   const tempoAttr = getAttribute(element, "tempo");
   const dynamicsAttr = getAttribute(element, "dynamics");
+  const dacapoAttr = getAttribute(element, "dacapo");
+  const segnoAttr = getAttribute(element, "segno");
+  const dalsegnoAttr = getAttribute(element, "dalsegno");
+  const codaAttr = getAttribute(element, "coda");
+  const tocodaAttr = getAttribute(element, "tocoda");
+  const divisionsAttr = getAttribute(element, "divisions");
+  const forwardRepeatAttr = getAttribute(element, "forward-repeat");
+  const fineAttr = getAttribute(element, "fine");
+  const timeOnlyAttr = getAttribute(element, "time-only");
+  const pizzicatoAttr = getAttribute(element, "pizzicato");
+  const panAttr = getAttribute(element, "pan");
+  const elevationAttr = getAttribute(element, "elevation");
+  const damperPedalAttr = getAttribute(element, "damper-pedal");
+  const softPedalAttr = getAttribute(element, "soft-pedal");
+  const sostenutoPedalAttr = getAttribute(element, "sostenuto-pedal");
+  const idAttr = getAttribute(element, "id");
 
   if (tempoAttr) {
     const tempo = parseFloat(tempoAttr);
@@ -1644,6 +1660,64 @@ export const mapSoundElement = (element: Element): Sound => {
     const dyn = parseFloat(dynamicsAttr);
     if (!isNaN(dyn)) soundData.dynamics = dyn;
   }
+  if (dacapoAttr === "yes" || dacapoAttr === "no") {
+    soundData.dacapo = dacapoAttr;
+  }
+  if (segnoAttr) soundData.segno = segnoAttr;
+  if (dalsegnoAttr) soundData.dalsegno = dalsegnoAttr;
+  if (codaAttr) soundData.coda = codaAttr;
+  if (tocodaAttr) soundData.tocoda = tocodaAttr;
+  if (divisionsAttr) {
+    const div = parseFloat(divisionsAttr);
+    if (!isNaN(div)) soundData.divisions = div;
+  }
+  if (forwardRepeatAttr === "yes" || forwardRepeatAttr === "no") {
+    soundData.forwardRepeat = forwardRepeatAttr;
+  }
+  if (fineAttr) soundData.fine = fineAttr;
+  if (timeOnlyAttr) soundData.timeOnly = timeOnlyAttr;
+  if (pizzicatoAttr === "yes" || pizzicatoAttr === "no") {
+    soundData.pizzicato = pizzicatoAttr;
+  }
+  if (panAttr) {
+    const pan = parseFloat(panAttr);
+    if (!isNaN(pan)) soundData.pan = pan;
+  }
+  if (elevationAttr) {
+    const elevation = parseFloat(elevationAttr);
+    if (!isNaN(elevation)) soundData.elevation = elevation;
+  }
+  if (damperPedalAttr) {
+    const val = damperPedalAttr === "yes" || damperPedalAttr === "no"
+      ? damperPedalAttr
+      : parseFloat(damperPedalAttr);
+    if (val === "yes" || val === "no") {
+      soundData.damperPedal = val;
+    } else if (!isNaN(val as number)) {
+      soundData.damperPedal = val as number;
+    }
+  }
+  if (softPedalAttr) {
+    const val = softPedalAttr === "yes" || softPedalAttr === "no"
+      ? softPedalAttr
+      : parseFloat(softPedalAttr);
+    if (val === "yes" || val === "no") {
+      soundData.softPedal = val;
+    } else if (!isNaN(val as number)) {
+      soundData.softPedal = val as number;
+    }
+  }
+  if (sostenutoPedalAttr) {
+    const val = sostenutoPedalAttr === "yes" || sostenutoPedalAttr === "no"
+      ? sostenutoPedalAttr
+      : parseFloat(sostenutoPedalAttr);
+    if (val === "yes" || val === "no") {
+      soundData.sostenutoPedal = val;
+    } else if (!isNaN(val as number)) {
+      soundData.sostenutoPedal = val as number;
+    }
+  }
+  if (idAttr) soundData.id = idAttr;
 
   return SoundSchema.parse(soundData);
 };

--- a/src/schemas/common.ts
+++ b/src/schemas/common.ts
@@ -32,4 +32,12 @@ export const LineWidthSchema = z.object({
 });
 export type LineWidth = z.infer<typeof LineWidthSchema>;
 
+/** Boolean yes/no or numeric value. Used for pedal playback levels. */
+export const YesNoNumberSchema = z.union([YesNoEnum, z.number()]);
+export type YesNoNumber = z.infer<typeof YesNoNumberSchema>;
+
+/** Rotation degrees from -180 to 180, used for pan and elevation. */
+export const RotationDegreesSchema = z.number().min(-180).max(180);
+export type RotationDegrees = z.infer<typeof RotationDegreesSchema>;
+
 // export {}; // Ensures this is treated as a module - can be removed if other exports exist

--- a/src/schemas/sound.ts
+++ b/src/schemas/sound.ts
@@ -1,9 +1,30 @@
 import { z } from "zod";
+import {
+  YesNoEnum,
+  YesNoNumberSchema,
+  RotationDegreesSchema,
+} from "./common";
 
 export const SoundSchema = z.object({
   _type: z.literal("sound"),
   tempo: z.number().optional(),
   dynamics: z.number().optional(),
+  dacapo: YesNoEnum.optional(),
+  segno: z.string().optional(),
+  dalsegno: z.string().optional(),
+  coda: z.string().optional(),
+  tocoda: z.string().optional(),
+  divisions: z.number().optional(),
+  forwardRepeat: YesNoEnum.optional(),
+  fine: z.string().optional(),
+  timeOnly: z.string().optional(),
+  pizzicato: YesNoEnum.optional(),
+  pan: RotationDegreesSchema.optional(),
+  elevation: RotationDegreesSchema.optional(),
+  damperPedal: YesNoNumberSchema.optional(),
+  softPedal: YesNoNumberSchema.optional(),
+  sostenutoPedal: YesNoNumberSchema.optional(),
+  id: z.string().optional(),
 });
 
 export type Sound = z.infer<typeof SoundSchema>;

--- a/tests/print-sound.test.ts
+++ b/tests/print-sound.test.ts
@@ -31,4 +31,29 @@ describe("Measure print and sound parsing", () => {
     expect(sound._type).toBe("sound");
     expect(sound.tempo).toBe(120);
   });
+
+  it("parses additional <sound> attributes", () => {
+    const xml =
+      `<measure number="1"><sound tempo="90" dacapo="yes" segno="seg1" dalsegno="ds1" ` +
+      `pizzicato="yes" pan="30" elevation="10" damper-pedal="50" soft-pedal="no" ` +
+      `sostenuto-pedal="yes" divisions="2" forward-repeat="no" fine="end" time-only="1,3" id="s1"/></measure>`;
+    const element = createElement(xml);
+    const measure = mapMeasureElement(element);
+    const sound = (measure.content?.[0] as Sound) ?? {};
+    expect(sound.tempo).toBe(90);
+    expect(sound.dacapo).toBe("yes");
+    expect(sound.segno).toBe("seg1");
+    expect(sound.dalsegno).toBe("ds1");
+    expect(sound.pizzicato).toBe("yes");
+    expect(sound.pan).toBe(30);
+    expect(sound.elevation).toBe(10);
+    expect(sound.damperPedal).toBe(50);
+    expect(sound.softPedal).toBe("no");
+    expect(sound.sostenutoPedal).toBe("yes");
+    expect(sound.divisions).toBe(2);
+    expect(sound.forwardRepeat).toBe("no");
+    expect(sound.fine).toBe("end");
+    expect(sound.timeOnly).toBe("1,3");
+    expect(sound.id).toBe("s1");
+  });
 });


### PR DESCRIPTION
## Summary
- extend `SoundSchema` with many playback attributes
- support these fields in `mapSoundElement`
- add tests for new sound attributes

## Testing
- `npm test`