### PR TITLE
Add full wedge attribute parsing

### DIFF
--- a/src/parser/mappers/noteMeasureMappers.ts
+++ b/src/parser/mappers/noteMeasureMappers.ts
@@ -802,6 +802,49 @@ const mapDirectionTypeElement = (element: Element): DirectionType => {
       const sp = parseFloat(spread);
       if (!isNaN(sp)) wedgeData.spread = sp;
     }
+    const numberAttr = getAttribute(wedgeElement, "number");
+    if (numberAttr) {
+      const num = parseOptionalInt(numberAttr);
+      if (num !== undefined) wedgeData.number = num;
+    }
+    const nienteAttr = getAttribute(wedgeElement, "niente");
+    if (nienteAttr === "yes" || nienteAttr === "no") wedgeData.niente = nienteAttr;
+    const lineTypeAttr = getAttribute(wedgeElement, "line-type");
+    if (lineTypeAttr) wedgeData.lineType = lineTypeAttr;
+    const dashLenAttr = getAttribute(wedgeElement, "dash-length");
+    if (dashLenAttr) {
+      const dl = parseOptionalFloat(dashLenAttr);
+      if (dl !== undefined) wedgeData.dashLength = dl;
+    }
+    const spaceLenAttr = getAttribute(wedgeElement, "space-length");
+    if (spaceLenAttr) {
+      const sl = parseOptionalFloat(spaceLenAttr);
+      if (sl !== undefined) wedgeData.spaceLength = sl;
+    }
+    const defaultXAttr = getAttribute(wedgeElement, "default-x");
+    if (defaultXAttr) {
+      const dx = parseOptionalFloat(defaultXAttr);
+      if (dx !== undefined) wedgeData.defaultX = dx;
+    }
+    const defaultYAttr = getAttribute(wedgeElement, "default-y");
+    if (defaultYAttr) {
+      const dy = parseOptionalFloat(defaultYAttr);
+      if (dy !== undefined) wedgeData.defaultY = dy;
+    }
+    const relativeXAttr = getAttribute(wedgeElement, "relative-x");
+    if (relativeXAttr) {
+      const rx = parseOptionalFloat(relativeXAttr);
+      if (rx !== undefined) wedgeData.relativeX = rx;
+    }
+    const relativeYAttr = getAttribute(wedgeElement, "relative-y");
+    if (relativeYAttr) {
+      const ry = parseOptionalFloat(relativeYAttr);
+      if (ry !== undefined) wedgeData.relativeY = ry;
+    }
+    const colorAttr = getAttribute(wedgeElement, "color");
+    if (colorAttr) wedgeData.color = colorAttr;
+    const idAttr = getAttribute(wedgeElement, "id");
+    if (idAttr) wedgeData.id = idAttr;
     directionTypeData.wedge = WedgeSchema.parse(wedgeData);
   }
   if (segnoElement) {

--- a/src/schemas/direction.ts
+++ b/src/schemas/direction.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { TextFormattingSchema } from "./credit"; // Assuming TextFormattingSchema includes font attributes
+import { YesNoEnum } from "./common";
 
 // Placeholder for MetronomeBeatUnitDotSchema if needed later
 // export const MetronomeBeatUnitDotSchema = z.object({});
@@ -50,6 +51,17 @@ export type Pedal = z.infer<typeof PedalSchema>;
 export const WedgeSchema = z.object({
   type: z.enum(["crescendo", "diminuendo", "stop", "continue"]).optional(),
   spread: z.number().optional(),
+  number: z.number().int().optional(),
+  niente: YesNoEnum.optional(),
+  lineType: z.string().optional(),
+  dashLength: z.number().optional(),
+  spaceLength: z.number().optional(),
+  defaultX: z.number().optional(),
+  defaultY: z.number().optional(),
+  relativeX: z.number().optional(),
+  relativeY: z.number().optional(),
+  color: z.string().optional(),
+  id: z.string().optional(),
 });
 export type Wedge = z.infer<typeof WedgeSchema>;
 

--- a/tests/direction.test.ts
+++ b/tests/direction.test.ts
@@ -47,4 +47,24 @@ describe("Direction parsing", () => {
     expect(dt.segno).toBeDefined();
     expect(dt.coda).toBeDefined();
   });
+
+  it("parses wedge with all attributes", () => {
+    const xml = `<direction><direction-type><wedge type="crescendo" number="3" spread="12.5" niente="yes" line-type="dashed" dash-length="1.2" space-length="2.3" default-x="4.5" default-y="-3" relative-x="1" relative-y="-2" color="red" id="w1"/></direction-type></direction>`;
+    const el = createElement(xml);
+    const direction = mapDirectionElement(el);
+    const wedge = direction.direction_type[0].wedge!;
+    expect(wedge.type).toBe("crescendo");
+    expect(wedge.number).toBe(3);
+    expect(wedge.spread).toBe(12.5);
+    expect(wedge.niente).toBe("yes");
+    expect(wedge.lineType).toBe("dashed");
+    expect(wedge.dashLength).toBe(1.2);
+    expect(wedge.spaceLength).toBe(2.3);
+    expect(wedge.defaultX).toBe(4.5);
+    expect(wedge.defaultY).toBe(-3);
+    expect(wedge.relativeX).toBe(1);
+    expect(wedge.relativeY).toBe(-2);
+    expect(wedge.color).toBe("red");
+    expect(wedge.id).toBe("w1");
+  });
 });


### PR DESCRIPTION
## Summary
- expand `WedgeSchema` with many optional attributes
- parse wedge attributes in `mapDirectionTypeElement`
- test parsing a wedge element with all attributes

## Testing
- `npm test`