### PR TITLE
Add ending attribute support

### DIFF
--- a/src/parser/mappers/noteMeasureMappers.ts
+++ b/src/parser/mappers/noteMeasureMappers.ts
@@ -904,7 +904,7 @@ const mapEndingElement = (element: Element): Ending => {
       '<ending> element requires "number" and "type" attributes.',
     );
   }
-  const endingData = {
+  const endingData: Partial<Ending> = {
     number: number,
     type: type,
     text: element.textContent?.trim() || undefined,
@@ -913,6 +913,64 @@ const mapEndingElement = (element: Element): Ending => {
       | "no"
       | undefined,
   };
+
+  const defaultXAttr = getAttribute(element, "default-x");
+  const defaultYAttr = getAttribute(element, "default-y");
+  const relativeXAttr = getAttribute(element, "relative-x");
+  const relativeYAttr = getAttribute(element, "relative-y");
+  const fontFamily = getAttribute(element, "font-family");
+  const fontStyleAttr = getAttribute(element, "font-style");
+  const fontSize = getAttribute(element, "font-size");
+  const fontWeightAttr = getAttribute(element, "font-weight");
+  const colorAttr = getAttribute(element, "color");
+  const systemAttr = getAttribute(element, "system") as
+    | "none"
+    | "only-top"
+    | "also-top"
+    | undefined;
+  const endLengthAttr = getAttribute(element, "end-length");
+  const textXAttr = getAttribute(element, "text-x");
+  const textYAttr = getAttribute(element, "text-y");
+
+  if (defaultXAttr) {
+    const val = parseFloat(defaultXAttr);
+    if (!isNaN(val)) endingData.defaultX = val;
+  }
+  if (defaultYAttr) {
+    const val = parseFloat(defaultYAttr);
+    if (!isNaN(val)) endingData.defaultY = val;
+  }
+  if (relativeXAttr) {
+    const val = parseFloat(relativeXAttr);
+    if (!isNaN(val)) endingData.relativeX = val;
+  }
+  if (relativeYAttr) {
+    const val = parseFloat(relativeYAttr);
+    if (!isNaN(val)) endingData.relativeY = val;
+  }
+  if (fontFamily) endingData.fontFamily = fontFamily;
+  if (fontSize) endingData.fontSize = fontSize;
+  if (colorAttr) endingData.color = colorAttr;
+  if (fontStyleAttr === "normal" || fontStyleAttr === "italic") {
+    endingData.fontStyle = fontStyleAttr;
+  }
+  if (fontWeightAttr === "normal" || fontWeightAttr === "bold") {
+    endingData.fontWeight = fontWeightAttr;
+  }
+  if (systemAttr) endingData.system = systemAttr;
+  if (endLengthAttr) {
+    const val = parseFloat(endLengthAttr);
+    if (!isNaN(val)) endingData.endLength = val;
+  }
+  if (textXAttr) {
+    const val = parseFloat(textXAttr);
+    if (!isNaN(val)) endingData.textX = val;
+  }
+  if (textYAttr) {
+    const val = parseFloat(textYAttr);
+    if (!isNaN(val)) endingData.textY = val;
+  }
+
   return EndingSchema.parse(endingData);
 };
 

--- a/src/schemas/barline.ts
+++ b/src/schemas/barline.ts
@@ -46,7 +46,21 @@ export const EndingSchema = z.object({
   type: z.enum(["start", "stop", "discontinue"]),
   text: z.string().optional(), // The text of the ending, e.g., "1.", "To Coda"
   "print-object": z.enum(["yes", "no"]).optional(),
-  // TODO: Add other attributes like text-x, text-y, end-length, etc.
+  // Position and font attributes from %print-style
+  defaultX: z.number().optional(),
+  defaultY: z.number().optional(),
+  relativeX: z.number().optional(),
+  relativeY: z.number().optional(),
+  fontFamily: z.string().optional(),
+  fontStyle: z.enum(["normal", "italic"]).optional(),
+  fontSize: z.string().optional(),
+  fontWeight: z.enum(["normal", "bold"]).optional(),
+  color: z.string().optional(),
+  // System relation and additional positioning attributes
+  system: z.enum(["none", "only-top", "also-top"]).optional(),
+  endLength: z.number().optional(),
+  textX: z.number().optional(),
+  textY: z.number().optional(),
 });
 export type Ending = z.infer<typeof EndingSchema>;
 

--- a/tests/barline.test.ts
+++ b/tests/barline.test.ts
@@ -132,5 +132,26 @@ describe("Barline Schema Tests", () => {
       expect(barline.divisions).toBe(480);
       expect(barline.id).toBe("b1");
     });
+
+    it("should parse ending attributes like end-length and system", () => {
+      const xml = `<barline><ending type="start" number="1" end-length="5" text-x="2" text-y="3" system="only-top" default-x="1" default-y="2" relative-x="-1" relative-y="-2" font-family="Arial" font-style="italic" font-size="12" font-weight="bold" color="#111111">1.</ending></barline>`;
+      const element = createElement(xml);
+      const barline = mapBarlineElement(element);
+      expect(barline.ending).toBeDefined();
+      const ending = barline.ending as Ending;
+      expect(ending.endLength).toBe(5);
+      expect(ending.textX).toBe(2);
+      expect(ending.textY).toBe(3);
+      expect(ending.system).toBe("only-top");
+      expect(ending.defaultX).toBe(1);
+      expect(ending.defaultY).toBe(2);
+      expect(ending.relativeX).toBe(-1);
+      expect(ending.relativeY).toBe(-2);
+      expect(ending.fontFamily).toBe("Arial");
+      expect(ending.fontStyle).toBe("italic");
+      expect(ending.fontSize).toBe("12");
+      expect(ending.fontWeight).toBe("bold");
+      expect(ending.color).toBe("#111111");
+    });
   });
 });


### PR DESCRIPTION
## Summary
- extend `EndingSchema` with print-style and system attributes
- parse new ending attributes in note measure mapper
- test new ending fields in barline parser

## Testing
- `npm test`