### PR TITLE
Add time-modification support

### DIFF
--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -38,6 +38,7 @@ export * from "./backup";
 export * from "./forward";
 export * from "./print";
 export * from "./sound";
+export * from "./timeModification";
 export * from "./fermata";
 export * from "./wavyLine";
 export * from "./editorial";

--- a/src/schemas/note.ts
+++ b/src/schemas/note.ts
@@ -10,6 +10,7 @@ import { BeamSchema } from "./beam";
 import { GraceSchema } from "./grace";
 import { CueSchema } from "./cue";
 import { UnpitchedSchema } from "./unpitched";
+import { TimeModificationSchema } from "./timeModification";
 
 /**
  * Represents a single musical note or rest.
@@ -26,6 +27,7 @@ export const NoteSchema = z
     unpitched: UnpitchedSchema.optional(),
     rest: RestSchema.optional(),
     duration: z.number().int().optional(),
+    timeModification: TimeModificationSchema.optional(),
     ties: z.array(TieSchema).max(2).optional(),
     type: z.string().optional(),
     dots: z.array(z.object({})).optional(),

--- a/src/schemas/timeModification.ts
+++ b/src/schemas/timeModification.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const TimeModificationSchema = z.object({
+  actualNotes: z.number().int(),
+  normalNotes: z.number().int(),
+  normalType: z.string().optional(),
+  normalDots: z.array(z.object({})).optional(),
+});
+
+export type TimeModification = z.infer<typeof TimeModificationSchema>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -122,6 +122,7 @@ export type {
 export type { Harmony } from "../schemas/harmony";
 export type { Print } from "../schemas/print";
 export type { Sound } from "../schemas/sound";
+export type { TimeModification } from "../schemas/timeModification";
 export type { MeasureContent } from "../schemas/measure";
 export type { Backup } from "../schemas/backup";
 export type { Forward } from "../schemas/forward";

--- a/tests/note.test.ts
+++ b/tests/note.test.ts
@@ -188,6 +188,18 @@ describe("Note Schema Tests (note.mod)", () => {
       expect(note.notations?.tuplets?.[0].number).toBe(3);
     });
 
+    it("parses tuplets via <time-modification>", () => {
+      const xml =
+        '<note><pitch><step>C</step><octave>4</octave></pitch><duration>1</duration><time-modification><actual-notes>3</actual-notes><normal-notes>2</normal-notes><normal-type>eighth</normal-type><normal-dot/></time-modification></note>';
+      const element = createElement(xml);
+      const note = mapNoteElement(element);
+      expect(note.timeModification).toBeDefined();
+      expect(note.timeModification?.actualNotes).toBe(3);
+      expect(note.timeModification?.normalNotes).toBe(2);
+      expect(note.timeModification?.normalType).toBe("eighth");
+      expect(note.timeModification?.normalDots).toHaveLength(1);
+    });
+
     // TODO: Add tests for tie, time-modification, notations (articulations, ornaments, technical), etc.
   });
 });


### PR DESCRIPTION
## Summary
- support `time-modification` in notes
- parse time modification element
- expose `TimeModification` type
- test tuplets via time-modification

## Testing
- `npm test`