### PR TITLE
Add missing MusicXML notations

### DIFF
--- a/src/parser/mappers/noteMeasureMappers.ts
+++ b/src/parser/mappers/noteMeasureMappers.ts
@@ -48,6 +48,10 @@ import type {
   Tuplet,
   Ornaments,
   Technical,
+  Glissando,
+  Slide,
+  Tremolo,
+  OtherNotation,
   Tie,
   Barline,
   BarStyle,
@@ -148,6 +152,10 @@ import {
   TupletSchema,
   OrnamentsSchema,
   TechnicalSchema,
+  GlissandoSchema,
+  SlideSchema,
+  TremoloSchema,
+  OtherNotationSchema,
   TieSchema,
   BarlineSchema,
   WavyLineSchema,
@@ -627,6 +635,62 @@ const mapTechnicalElement = (_element: Element): Technical => {
   return TechnicalSchema.parse({});
 };
 
+const mapGlissandoElement = (element: Element): Glissando => {
+  const glissandoData: Partial<Glissando> = {
+    value: element.textContent?.trim() || undefined,
+    type: getAttribute(element, "type") as "start" | "stop" | undefined,
+    number: parseOptionalNumberAttribute(element, "number"),
+  };
+  if (!glissandoData.type) {
+    throw new Error('<glissando> element requires a "type" attribute.');
+  }
+  return GlissandoSchema.parse(glissandoData);
+};
+
+const mapSlideElement = (element: Element): Slide => {
+  const slideData: Partial<Slide> = {
+    value: element.textContent?.trim() || undefined,
+    type: getAttribute(element, "type") as "start" | "stop" | undefined,
+    number: parseOptionalNumberAttribute(element, "number"),
+  };
+  if (!slideData.type) {
+    throw new Error('<slide> element requires a "type" attribute.');
+  }
+  return SlideSchema.parse(slideData);
+};
+
+const mapTremoloElement = (element: Element): Tremolo => {
+  const valueText = element.textContent?.trim();
+  const marks = valueText ? parseInt(valueText, 10) : undefined;
+  const tremoloData: Partial<Tremolo> = {
+    value: marks ?? 0,
+  };
+  const typeAttr = getAttribute(element, "type") as
+    | "single"
+    | "start"
+    | "stop"
+    | "unmeasured"
+    | undefined;
+  if (typeAttr) tremoloData.type = typeAttr;
+  return TremoloSchema.parse(tremoloData);
+};
+
+const mapOtherNotationElement = (element: Element): OtherNotation => {
+  const data: Partial<OtherNotation> = {
+    value: element.textContent?.trim() || undefined,
+    type: getAttribute(element, "type") as
+      | "start"
+      | "stop"
+      | "single"
+      | undefined,
+    number: parseOptionalNumberAttribute(element, "number"),
+  };
+  if (!data.type) {
+    throw new Error('<other-notation> element requires a "type" attribute.');
+  }
+  return OtherNotationSchema.parse(data);
+};
+
 // Helper function to map a <words> element (within <direction-type>)
 const mapWordsElement = (element: Element): Words => {
   const text = element.textContent?.trim() ?? "";
@@ -843,6 +907,12 @@ const mapNotationsElement = (element: Element): Notations => {
   const tupletElements = Array.from(element.querySelectorAll("tuplet"));
   const ornamentsElements = Array.from(element.querySelectorAll("ornaments"));
   const technicalElements = Array.from(element.querySelectorAll("technical"));
+  const glissandoElements = Array.from(element.querySelectorAll("glissando"));
+  const slideElements = Array.from(element.querySelectorAll("slide"));
+  const tremoloElements = Array.from(element.querySelectorAll("tremolo"));
+  const otherNotationElements = Array.from(
+    element.querySelectorAll("other-notation"),
+  );
 
   const notationsData: Partial<Notations> = {};
 
@@ -865,6 +935,20 @@ const mapNotationsElement = (element: Element): Notations => {
   }
   if (technicalElements.length > 0) {
     notationsData.technical = technicalElements.map(mapTechnicalElement);
+  }
+  if (glissandoElements.length > 0) {
+    notationsData.glissandos = glissandoElements.map(mapGlissandoElement);
+  }
+  if (slideElements.length > 0) {
+    notationsData.slides = slideElements.map(mapSlideElement);
+  }
+  if (tremoloElements.length > 0) {
+    notationsData.tremolos = tremoloElements.map(mapTremoloElement);
+  }
+  if (otherNotationElements.length > 0) {
+    notationsData.otherNotations = otherNotationElements.map(
+      mapOtherNotationElement,
+    );
   }
 
   return NotationsSchema.parse(notationsData);

--- a/src/schemas/notations.ts
+++ b/src/schemas/notations.ts
@@ -70,6 +70,45 @@ export const TechnicalSchema = z.object({});
 export type Technical = z.infer<typeof TechnicalSchema>;
 
 /**
+ * Represents a glissando notation.
+ */
+export const GlissandoSchema = z.object({
+  value: z.string().optional(),
+  type: z.enum(["start", "stop"]),
+  number: z.number().int().optional(),
+});
+export type Glissando = z.infer<typeof GlissandoSchema>;
+
+/**
+ * Represents a slide notation.
+ */
+export const SlideSchema = z.object({
+  value: z.string().optional(),
+  type: z.enum(["start", "stop"]),
+  number: z.number().int().optional(),
+});
+export type Slide = z.infer<typeof SlideSchema>;
+
+/**
+ * Represents a tremolo notation.
+ */
+export const TremoloSchema = z.object({
+  value: z.number().int(),
+  type: z.enum(["single", "start", "stop", "unmeasured"]).optional(),
+});
+export type Tremolo = z.infer<typeof TremoloSchema>;
+
+/**
+ * Represents an other-notation element.
+ */
+export const OtherNotationSchema = z.object({
+  value: z.string().optional(),
+  type: z.enum(["start", "stop", "single"]),
+  number: z.number().int().optional(),
+});
+export type OtherNotation = z.infer<typeof OtherNotationSchema>;
+
+/**
  * The articulations element groups multiple articulation marks.
  */
 export const ArticulationsSchema = z.object({
@@ -94,5 +133,9 @@ export const NotationsSchema = z.object({
   tuplets: z.array(TupletSchema).optional(),
   ornaments: z.array(OrnamentsSchema).optional(),
   technical: z.array(TechnicalSchema).optional(),
+  glissandos: z.array(GlissandoSchema).optional(),
+  slides: z.array(SlideSchema).optional(),
+  tremolos: z.array(TremoloSchema).optional(),
+  otherNotations: z.array(OtherNotationSchema).optional(),
 });
 export type Notations = z.infer<typeof NotationsSchema>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -62,6 +62,10 @@ export type {
   Tuplet,
   Ornaments,
   Technical,
+  Glissando,
+  Slide,
+  Tremolo,
+  OtherNotation,
 } from "../schemas/notations";
 export type { Barline, BarStyle, Repeat, Ending } from "../schemas/barline";
 export type { Fermata, FermataShape } from "../schemas/fermata";

--- a/tests/note.test.ts
+++ b/tests/note.test.ts
@@ -188,6 +188,21 @@ describe("Note Schema Tests (note.mod)", () => {
       expect(note.notations?.tuplets?.[0].number).toBe(3);
     });
 
+    it("parses glissando, slide, tremolo and other-notation", () => {
+      const xml =
+        '<note><pitch><step>E</step><octave>5</octave></pitch><duration>1</duration><notations><glissando type="start">gliss</glissando><slide type="stop"/><tremolo type="single">3</tremolo><other-notation type="single">x</other-notation></notations></note>';
+      const element = createElement(xml);
+      const note = mapNoteElement(element);
+      expect(note.notations?.glissandos).toHaveLength(1);
+      expect(note.notations?.slides).toHaveLength(1);
+      expect(note.notations?.tremolos).toHaveLength(1);
+      expect(note.notations?.otherNotations).toHaveLength(1);
+      expect(note.notations?.glissandos?.[0].type).toBe("start");
+      expect(note.notations?.slides?.[0].type).toBe("stop");
+      expect(note.notations?.tremolos?.[0].value).toBe(3);
+      expect(note.notations?.otherNotations?.[0].type).toBe("single");
+    });
+
     // TODO: Add tests for tie, time-modification, notations (articulations, ornaments, technical), etc.
   });
 });


### PR DESCRIPTION
## Summary
- extend notation schemas with Glissando, Slide, Tremolo and OtherNotation
- map these elements in note parsing
- export new types
- test parsing of these additional notations

## Testing
- `npm test`
- `npm run format:check`
