### PR TITLE
Add part-group support

### DIFF
--- a/src/parser/mappers/noteMeasureMappers.ts
+++ b/src/parser/mappers/noteMeasureMappers.ts
@@ -6,6 +6,7 @@ import type {
   Part,
   ScorePart,
   PartList,
+  PartGroup,
   ScorePartwise,
   Key,
   Time,
@@ -65,6 +66,7 @@ import type {
   Beam,
   BeamValue,
   PartSymbol,
+  GroupSymbolValue,
   Lyric,
   Grace,
   Cue,
@@ -108,6 +110,7 @@ import {
   PartSchema,
   ScorePartSchema,
   PartListSchema,
+  PartGroupSchema,
   ScorePartwiseSchema,
   ScoreTimewiseSchema,
   TimewisePartSchema,
@@ -1899,13 +1902,35 @@ export const mapScorePartElement = (element: Element): ScorePart => {
   return ScorePartSchema.parse(scorePartData);
 };
 
+// Mapper for <part-group> element within <part-list>
+export const mapPartGroupElement = (element: Element): PartGroup => {
+  const groupData: Partial<PartGroup> = {
+    number: getAttribute(element, "number") ?? undefined,
+    type: (getAttribute(element, "type") as "start" | "stop") ?? "start",
+  };
+
+  const name = getTextContent(element, "group-name");
+  if (name) groupData.groupName = name;
+  const abbr = getTextContent(element, "group-abbreviation");
+  if (abbr) groupData.groupAbbreviation = abbr;
+  const symbol = getTextContent(element, "group-symbol");
+  if (symbol && GroupSymbolValueEnum.safeParse(symbol).success) {
+    groupData.groupSymbol = symbol as GroupSymbolValue;
+  }
+  const barline = getTextContent(element, "group-barline");
+  if (barline === "yes" || barline === "no") groupData.groupBarline = barline;
+
+  return PartGroupSchema.parse(groupData);
+};
+
 // Mapper for <part-list> element
 export const mapPartListElement = (element: Element): PartList => {
   const scorePartElements = Array.from(element.querySelectorAll("score-part"));
+  const partGroupElements = Array.from(element.querySelectorAll("part-group"));
   // console.log('Mapping PartList, found scorePartElements:', scorePartElements.length);
   const partListData = {
     scoreParts: scorePartElements.map(mapScorePartElement),
-    // Potentially handle <part-group> elements here as well
+    partGroups: partGroupElements.map(mapPartGroupElement),
   };
   // console.log('Parsed partListData:', JSON.stringify(partListData, null, 2));
 

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -28,6 +28,7 @@ export * from "./identification";
 export * from "./stem";
 export * from "./beam";
 export * from "./partSymbol";
+export * from "./partGroup";
 export * from "./grace";
 export * from "./cue";
 export * from "./unpitched";

--- a/src/schemas/partGroup.ts
+++ b/src/schemas/partGroup.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+import { GroupSymbolValueEnum } from "./partSymbol";
+import { YesNoEnum } from "./common";
+
+/**
+ * Represents a <part-group> element used within the <part-list>.
+ * Part groups allow multiple parts to be visually and logically grouped
+ * together. A part-group element can either start or stop a group.
+ */
+export const PartGroupSchema = z
+  .object({
+    /** Number identifying this group. Parts with the same number belong together. */
+    number: z.string().optional(),
+    /** Indicates whether this element starts or stops the group. */
+    type: z.enum(["start", "stop"]),
+    /** Optional name for the group, displayed above the bracket or brace. */
+    groupName: z.string().optional(), // <group-name>
+    /** Abbreviated name for the group. */
+    groupAbbreviation: z.string().optional(), // <group-abbreviation>
+    /** Symbol used to indicate the group visually. */
+    groupSymbol: GroupSymbolValueEnum.optional(), // <group-symbol>
+    /** Whether barlines are drawn for the group. */
+    groupBarline: YesNoEnum.optional(), // <group-barline>
+  })
+  .passthrough();
+
+export type PartGroup = z.infer<typeof PartGroupSchema>;

--- a/src/schemas/partList.ts
+++ b/src/schemas/partList.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { ScorePartSchema } from "./scorePart";
+import { PartGroupSchema } from "./partGroup";
 
 /**
  * Represents the <part-list> element in a MusicXML score.
@@ -13,7 +14,8 @@ export const PartListSchema = z
      * A score must have at least one part listed.
      */
     scoreParts: z.array(ScorePartSchema).min(1), // <score-part>
-    // partGroups: z.array(PartGroupSchema).optional(), // <part-group> - Requires PartGroupSchema
+    /** Optional array of <part-group> elements for grouping parts. */
+    partGroups: z.array(PartGroupSchema).optional(), // <part-group>
   })
   .passthrough(); // Allows other elements/attributes not explicitly defined
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,6 +4,7 @@ export type { Note } from "../schemas/note";
 export type { Measure } from "../schemas/measure";
 export type { Part } from "../schemas/part";
 export type { ScorePart } from "../schemas/scorePart";
+export type { PartGroup } from "../schemas/partGroup";
 export type { PartList } from "../schemas/partList";
 export type { ScorePartwise } from "../schemas/scorePartwise";
 export type { ScoreTimewise } from "../schemas/scoreTimewise";

--- a/tests/partList.test.ts
+++ b/tests/partList.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { parseMusicXmlString } from "../src/parser/xmlParser";
+import { mapDocumentToScorePartwise } from "../src/parser/mappers";
+
+const groupedXml = `
+<score-partwise version="3.1">
+  <part-list>
+    <part-group number="1" type="start">
+      <group-name>Winds</group-name>
+      <group-symbol>bracket</group-symbol>
+      <group-barline>yes</group-barline>
+    </part-group>
+    <score-part id="P1">
+      <part-name>Flute</part-name>
+    </score-part>
+    <score-part id="P2">
+      <part-name>Oboe</part-name>
+    </score-part>
+    <part-group number="1" type="stop"/>
+  </part-list>
+  <part id="P1"><measure number="1"/></part>
+  <part id="P2"><measure number="1"/></part>
+</score-partwise>`;
+
+describe("Part-list parsing", () => {
+  it("maps part-group elements", async () => {
+    const doc = await parseMusicXmlString(groupedXml);
+    expect(doc).not.toBeNull();
+    if (!doc) return;
+    const score = mapDocumentToScorePartwise(doc);
+    expect(score.partList.partGroups).toBeDefined();
+    expect(score.partList.partGroups?.length).toBe(2);
+    const startGroup = score.partList.partGroups?.[0];
+    const stopGroup = score.partList.partGroups?.[1];
+    expect(startGroup?.type).toBe("start");
+    expect(startGroup?.groupName).toBe("Winds");
+    expect(startGroup?.groupSymbol).toBe("bracket");
+    expect(stopGroup?.type).toBe("stop");
+    expect(stopGroup?.number).toBe("1");
+  });
+});


### PR DESCRIPTION
## Summary
- add `PartGroupSchema` for `<part-group>` details
- extend `PartListSchema` with optional `partGroups`
- handle part-group mapping in `mapPartListElement`
- export new schema and types
- test grouped parts parsing

## Testing
- `npm test`