### PR TITLE
Add Opus field to work schema

### DIFF
--- a/src/parser/mappers/noteMeasureMappers.ts
+++ b/src/parser/mappers/noteMeasureMappers.ts
@@ -63,6 +63,7 @@ import type {
   Footnote,
   Level,
   Work,
+  Opus,
   Identification,
   Creator,
   Rights,
@@ -169,6 +170,7 @@ import {
   EndingSchema,
   FermataSchema,
   WorkSchema,
+  OpusSchema,
   IdentificationSchema,
   CreatorSchema,
   RightsSchema,
@@ -1207,10 +1209,30 @@ export const mapBarlineElement = (element: Element): Barline => {
 
 // Helper function to map a <work> element
 const mapWorkElement = (element: Element): Work => {
-  const workData = {
+  const workData: Partial<Work> = {
     "work-number": getTextContent(element, "work-number"),
     "work-title": getTextContent(element, "work-title"),
   };
+
+  const opusElement = element.querySelector("opus");
+  if (opusElement) {
+    const opusData: Partial<Opus> = {
+      href: getAttribute(opusElement, "xlink:href") ?? "",
+    };
+    const typeAttr = getAttribute(opusElement, "xlink:type");
+    if (typeAttr) opusData.type = typeAttr;
+    const roleAttr = getAttribute(opusElement, "xlink:role");
+    if (roleAttr) opusData.role = roleAttr;
+    const titleAttr = getAttribute(opusElement, "xlink:title");
+    if (titleAttr) opusData.title = titleAttr;
+    const showAttr = getAttribute(opusElement, "xlink:show");
+    if (showAttr) opusData.show = showAttr;
+    const actuateAttr = getAttribute(opusElement, "xlink:actuate");
+    if (actuateAttr) opusData.actuate = actuateAttr;
+
+    workData.opus = OpusSchema.parse(opusData);
+  }
+
   return WorkSchema.parse(workData);
 };
 

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -24,6 +24,7 @@ export * from "./accidental";
 export * from "./notations";
 export * from "./barline";
 export * from "./work";
+export * from "./opus";
 export * from "./identification";
 export * from "./stem";
 export * from "./beam";

--- a/src/schemas/opus.ts
+++ b/src/schemas/opus.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+/**
+ * Represents the <opus> element which links to an external MusicXML opus document.
+ * It uses the MusicXML link-attributes group (xlink attributes).
+ */
+export const OpusSchema = z.object({
+  href: z.string(),
+  type: z.string().optional(),
+  role: z.string().optional(),
+  title: z.string().optional(),
+  show: z.string().optional(),
+  actuate: z.string().optional(),
+});
+
+export type Opus = z.infer<typeof OpusSchema>;
+

--- a/src/schemas/work.ts
+++ b/src/schemas/work.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { OpusSchema } from "./opus";
 
 /**
  * The work complex type represents a musical work, including titles and numbers.
@@ -12,7 +13,10 @@ export const WorkSchema = z.object({
    * The work-title element is used for the title of a work.
    */
   "work-title": z.string().optional(),
-  // TODO: Add other work elements like <opus/> (though <opus/> is often part of <work-number> or handled separately)
+  /**
+   * Optional link to an external MusicXML opus document.
+   */
+  opus: OpusSchema.optional(),
 });
 
 export type Work = z.infer<typeof WorkSchema>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -67,6 +67,7 @@ export type {
 export type { Barline, BarStyle, Repeat, Ending } from "../schemas/barline";
 export type { Fermata, FermataShape } from "../schemas/fermata";
 export type { Work } from "../schemas/work";
+export type { Opus } from "../schemas/opus";
 export type {
   Identification,
   Creator,

--- a/tests/work.test.ts
+++ b/tests/work.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { parseMusicXmlString } from "../src/parser/xmlParser";
+import { mapDocumentToScorePartwise } from "../src/parser/mappers";
+
+const xml = `
+<score-partwise version="3.1" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <work>
+    <work-number>1</work-number>
+    <work-title>Test Piece</work-title>
+    <opus xlink:href="collection.opus" xlink:type="simple" xlink:title="Album"/>
+  </work>
+  <part-list>
+    <score-part id="P1"><part-name>Music</part-name></score-part>
+  </part-list>
+  <part id="P1"><measure number="1"/></part>
+</score-partwise>`;
+
+describe("Work element parsing", () => {
+  it("maps opus element when present", async () => {
+    const doc = await parseMusicXmlString(xml);
+    expect(doc).not.toBeNull();
+    if (!doc) return;
+    const score = mapDocumentToScorePartwise(doc);
+    expect(score.work).toBeDefined();
+    expect(score.work?.opus).toBeDefined();
+    expect(score.work?.opus?.href).toBe("collection.opus");
+    expect(score.work?.opus?.type).toBe("simple");
+    expect(score.work?.opus?.title).toBe("Album");
+  });
+});
+


### PR DESCRIPTION
## Summary
- support `<opus>` link info in the work schema
- parse opus attributes in the work element mapper
- expose `Opus` type and schema
- test parsing a work with an opus element

## Testing
- `npm test`