### PR TITLE
Add MIDI schemas and score-part parsing

### DIFF
--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -43,3 +43,6 @@ export * from "./timeModification";
 export * from "./fermata";
 export * from "./wavyLine";
 export * from "./editorial";
+export * from "./scoreInstrument";
+export * from "./midiDevice";
+export * from "./midiInstrument";

--- a/src/schemas/midiDevice.ts
+++ b/src/schemas/midiDevice.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const MidiDeviceSchema = z.object({
+  value: z.string(),
+  port: z.number().int().min(1).max(16).optional(),
+  id: z.string().optional(),
+});
+
+export type MidiDevice = z.infer<typeof MidiDeviceSchema>;

--- a/src/schemas/midiInstrument.ts
+++ b/src/schemas/midiInstrument.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+import { RotationDegreesSchema } from "./common";
+
+export const MidiInstrumentSchema = z
+  .object({
+    id: z.string(),
+    midiChannel: z.number().int().min(1).max(16).optional(),
+    midiName: z.string().optional(),
+    midiBank: z.number().int().min(1).max(16384).optional(),
+    midiProgram: z.number().int().min(1).max(128).optional(),
+    midiUnpitched: z.number().int().min(1).max(128).optional(),
+    volume: z.number().optional(),
+    pan: RotationDegreesSchema.optional(),
+    elevation: RotationDegreesSchema.optional(),
+  })
+  .passthrough();
+
+export type MidiInstrument = z.infer<typeof MidiInstrumentSchema>;

--- a/src/schemas/scoreInstrument.ts
+++ b/src/schemas/scoreInstrument.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+import { MidiInstrumentSchema } from "./midiInstrument";
+
+export const ScoreInstrumentSchema = z
+  .object({
+    id: z.string(),
+    instrumentName: z.string(),
+    instrumentAbbreviation: z.string().optional(),
+    instrumentSound: z.string().optional(),
+    solo: z.boolean().optional(),
+    ensemble: z.number().int().optional(),
+    midiInstrument: MidiInstrumentSchema.optional(),
+  })
+  .passthrough();
+
+export type ScoreInstrument = z.infer<typeof ScoreInstrumentSchema>;

--- a/src/schemas/scorePart.ts
+++ b/src/schemas/scorePart.ts
@@ -1,4 +1,7 @@
 import { z } from "zod";
+import { ScoreInstrumentSchema } from "./scoreInstrument";
+import { MidiDeviceSchema } from "./midiDevice";
+import { MidiInstrumentSchema } from "./midiInstrument";
 
 /**
  * Represents a single entry in the <part-list>, defining a part in the score.
@@ -15,10 +18,9 @@ export const ScorePartSchema = z
     partName: z.string().optional(), // <part-name>
     /** An abbreviated name for the part. Optional. */
     partAbbreviation: z.string().optional(), // <part-abbreviation>
-    // Other common elements within <score-part>:
-    // scoreInstrument: z.array(ScoreInstrumentSchema).optional(), // <score-instrument> - Requires ScoreInstrumentSchema
-    // midiDevice: MidiDeviceSchema.optional(), // <midi-device> - Requires MidiDeviceSchema
-    // midiInstrument: MidiInstrumentSchema.optional(), // <midi-instrument> - Requires MidiInstrumentSchema
+    scoreInstruments: z.array(ScoreInstrumentSchema).optional(),
+    midiDevices: z.array(MidiDeviceSchema).optional(),
+    midiInstruments: z.array(MidiInstrumentSchema).optional(),
   })
   .passthrough(); // Allows other elements/attributes not explicitly defined
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -137,6 +137,9 @@ export type {
   Tremolo,
   OtherNotation,
 } from "../schemas/notations";
+export type { ScoreInstrument } from "../schemas/scoreInstrument";
+export type { MidiDevice } from "../schemas/midiDevice";
+export type { MidiInstrument } from "../schemas/midiInstrument";
 export type { TimeModification } from "../schemas/timeModification";
 // Add other inferred types from Zod schemas here as they are created.
 

--- a/tests/scorePartMidi.test.ts
+++ b/tests/scorePartMidi.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { parseMusicXmlString } from "../src/parser/xmlParser";
+import { mapDocumentToScorePartwise } from "../src/parser/mappers";
+
+const xml = `
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      <part-abbreviation>Pno.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Piano</instrument-name>
+        <instrument-sound>keyboard.piano</instrument-sound>
+      </score-instrument>
+      <midi-device id="P1-I1" port="1">Device</midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>80</volume>
+        <pan>0</pan>
+      </midi-instrument>
+    </score-part>
+  </part-list>
+  <part id="P1"><measure number="1"/></part>
+</score-partwise>`;
+
+describe("Score-part MIDI parsing", () => {
+  it("maps score-instrument and MIDI elements", async () => {
+    const doc = await parseMusicXmlString(xml);
+    expect(doc).not.toBeNull();
+    if (!doc) return;
+    const score = mapDocumentToScorePartwise(doc);
+    const part = score.partList.scoreParts[0];
+    expect(part.partName).toBe("Piano");
+    expect(part.partAbbreviation).toBe("Pno.");
+    expect(part.scoreInstruments?.length).toBe(1);
+    const instr = part.scoreInstruments?.[0];
+    expect(instr?.instrumentName).toBe("Piano");
+    expect(instr?.instrumentSound).toBe("keyboard.piano");
+    expect(part.midiDevices?.[0].value).toBe("Device");
+    expect(part.midiDevices?.[0].port).toBe(1);
+    expect(part.midiInstruments?.[0].midiChannel).toBe(1);
+    expect(part.midiInstruments?.[0].midiProgram).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- support score-instrument and MIDI information
- parse MIDI device and instrument data in `<score-part>`
- test score-part MIDI parsing

## Testing
- `npm test`