### PR TITLE
Add metronome-note support

### DIFF
--- a/src/parser/mappers/noteMeasureMappers.ts
+++ b/src/parser/mappers/noteMeasureMappers.ts
@@ -18,6 +18,8 @@ import type {
   Metronome,
   MetronomeBeatUnit,
   MetronomePerMinute,
+  MetronomeNote,
+  MetronomeRelation,
   // Dynamics,
   Wedge,
   // Segno,
@@ -130,6 +132,7 @@ import {
   MetronomeSchema,
   MetronomeBeatUnitSchema,
   MetronomePerMinuteSchema,
+  MetronomeNoteSchema,
   TransposeSchema,
   // DiatonicSchema,
   // ChromaticSchema,
@@ -834,10 +837,24 @@ const mapMetronomePerMinuteElement = (element: Element): MetronomePerMinute => {
   return MetronomePerMinuteSchema.parse(perMinuteData);
 };
 
+// Helper to map <metronome-note>
+const mapMetronomeNoteElement = (element: Element): MetronomeNote => {
+  const typeElement = element.querySelector("metronome-type");
+  const dotElements = Array.from(element.querySelectorAll("metronome-dot"));
+  const noteData: Partial<MetronomeNote> = {};
+  if (typeElement) noteData["metronome-type"] = typeElement.textContent?.trim() ?? "";
+  if (dotElements.length > 0) noteData["metronome-dot"] = dotElements.map(() => ({}));
+  return MetronomeNoteSchema.parse(noteData);
+};
+
 // Helper function to map a <metronome> element (within <direction-type>)
 const mapMetronomeElement = (element: Element): Metronome => {
   const beatUnitElement = element.querySelector("beat-unit");
   const perMinuteElement = element.querySelector("per-minute");
+  const metronomeNoteElements = Array.from(
+    element.querySelectorAll("metronome-note"),
+  );
+  const relationElement = element.querySelector("metronome-relation");
   const metronomeData: Partial<Metronome> = {};
   if (beatUnitElement) {
     metronomeData["beat-unit"] = mapMetronomeBeatUnitElement(beatUnitElement);
@@ -845,6 +862,14 @@ const mapMetronomeElement = (element: Element): Metronome => {
   if (perMinuteElement) {
     metronomeData["per-minute"] =
       mapMetronomePerMinuteElement(perMinuteElement);
+  }
+  if (metronomeNoteElements.length > 0) {
+    metronomeData["metronome-note"] = metronomeNoteElements.map(
+      mapMetronomeNoteElement,
+    );
+  }
+  if (relationElement) {
+    metronomeData["metronome-relation"] = relationElement.textContent?.trim() ?? "";
   }
   return MetronomeSchema.parse(metronomeData);
 };
@@ -971,11 +996,16 @@ export const mapDirectionElement = (element: Element): Direction => {
     | "between"
     | undefined;
   const staff = parseOptionalNumberAttribute(element, "staff");
+  const directiveAttr = getAttribute(element, "directive") as
+    | "yes"
+    | "no"
+    | undefined;
   const directionData: Partial<Direction> = {
     _type: "direction",
     direction_type: directionTypeElements.map(mapDirectionTypeElement),
     placement: placement,
     staff: staff,
+    directive: directiveAttr,
   };
   return DirectionSchema.parse(directionData);
 };

--- a/src/schemas/direction.ts
+++ b/src/schemas/direction.ts
@@ -26,10 +26,22 @@ export const MetronomePerMinuteSchema = z.object({
 });
 export type MetronomePerMinute = z.infer<typeof MetronomePerMinuteSchema>;
 
+export const MetronomeNoteSchema = z.object({
+  "metronome-type": z.string().optional(),
+  "metronome-dot": z.array(z.object({})).optional(),
+});
+export type MetronomeNote = z.infer<typeof MetronomeNoteSchema>;
+
+export const MetronomeRelationSchema = z.object({
+  "metronome-relation": z.string().optional(),
+});
+export type MetronomeRelation = z.infer<typeof MetronomeRelationSchema>;
+
 export const MetronomeSchema = z.object({
   "beat-unit": MetronomeBeatUnitSchema.optional(),
   "per-minute": MetronomePerMinuteSchema.optional(),
-  // TODO: Add other metronome children like <metronome-note>, <metronome-relation>
+  "metronome-note": z.array(MetronomeNoteSchema).optional(),
+  "metronome-relation": z.string().optional(),
   // parentheses: z.boolean().optional(), // Example attribute
 });
 export type Metronome = z.infer<typeof MetronomeSchema>;
@@ -105,6 +117,6 @@ export const DirectionSchema = z.object({
    * If absent, the direction applies to all staves in the part (e.g., for a Grand Staff).
    */
   staff: z.number().int().optional(),
-  // TODO: Add other <direction> attributes like `directive`
+  directive: YesNoEnum.optional(),
 });
 export type Direction = z.infer<typeof DirectionSchema>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -23,6 +23,8 @@ export type {
   Metronome,
   MetronomeBeatUnit,
   MetronomePerMinute,
+  MetronomeNote,
+  MetronomeRelation,
   Dynamics,
   Pedal,
   Wedge,

--- a/tests/direction.test.ts
+++ b/tests/direction.test.ts
@@ -67,4 +67,23 @@ describe("Direction parsing", () => {
     expect(wedge.color).toBe("red");
     expect(wedge.id).toBe("w1");
   });
+
+  it("parses metronome notes and relation", () => {
+    const xml = `<direction><direction-type><metronome><metronome-note><metronome-type>quarter</metronome-type><metronome-dot/></metronome-note><metronome-relation>equals</metronome-relation><metronome-note><metronome-type>eighth</metronome-type></metronome-note></metronome></direction-type></direction>`;
+    const el = createElement(xml);
+    const direction = mapDirectionElement(el);
+    const met = direction.direction_type[0].metronome!;
+    expect(met["metronome-note"]?.length).toBe(2);
+    expect(met["metronome-note"]?.[0]["metronome-type"]).toBe("quarter");
+    expect(met["metronome-note"]?.[0]["metronome-dot"]?.length).toBe(1);
+    expect(met["metronome-relation"]).toBe("equals");
+    expect(met["metronome-note"]?.[1]["metronome-type"]).toBe("eighth");
+  });
+
+  it("parses directive attribute", () => {
+    const xml = `<direction directive="yes"><direction-type><words>Tempo</words></direction-type></direction>`;
+    const el = createElement(xml);
+    const direction = mapDirectionElement(el);
+    expect(direction.directive).toBe("yes");
+  });
 });


### PR DESCRIPTION
## Summary
- extend `direction` schema with metronome-note, metronome-relation and directive attribute
- parse metronome-note and relation in direction mappers
- handle directive attribute
- test new metronome-note and directive functionality

## Testing
- `npm test`