### PR TITLE
Add slur attribute support

### DIFF
--- a/src/parser/mappers/noteMeasureMappers.ts
+++ b/src/parser/mappers/noteMeasureMappers.ts
@@ -520,15 +520,44 @@ const mapClefElement = (element: Element): Clef => {
 
 // Helper function to map a <slur> element
 const mapSlurElement = (element: Element): Slur => {
-  const slurData = {
+  const slurData: Partial<Slur> = {
     type: getAttribute(element, "type") as "start" | "stop" | "continue",
     number: parseOptionalNumberAttribute(element, "number"),
     placement: getAttribute(element, "placement") as
       | "above"
       | "below"
       | undefined,
-    // TODO: Map other slur attributes
   };
+
+  const orientation = getAttribute(element, "orientation");
+  if (orientation === "over" || orientation === "under")
+    slurData.orientation = orientation;
+
+  const colorAttr = getAttribute(element, "color");
+  if (colorAttr) slurData.color = colorAttr;
+
+  const lineTypeAttr = getAttribute(element, "line-type");
+  if (lineTypeAttr) slurData.lineType = lineTypeAttr;
+
+  const bezierXAttr = getAttribute(element, "bezier-x");
+  if (bezierXAttr) slurData.bezierX = parseOptionalFloat(bezierXAttr);
+
+  const bezierYAttr = getAttribute(element, "bezier-y");
+  if (bezierYAttr) slurData.bezierY = parseOptionalFloat(bezierYAttr);
+
+  const bezierX2Attr = getAttribute(element, "bezier-x2");
+  if (bezierX2Attr) slurData.bezierX2 = parseOptionalFloat(bezierX2Attr);
+
+  const bezierY2Attr = getAttribute(element, "bezier-y2");
+  if (bezierY2Attr) slurData.bezierY2 = parseOptionalFloat(bezierY2Attr);
+
+  const bezierOffsetAttr = getAttribute(element, "bezier-offset");
+  if (bezierOffsetAttr)
+    slurData.bezierOffset = parseOptionalFloat(bezierOffsetAttr);
+
+  const bezierOffset2Attr = getAttribute(element, "bezier-offset2");
+  if (bezierOffset2Attr)
+    slurData.bezierOffset2 = parseOptionalFloat(bezierOffset2Attr);
   // Validate that type is one of the expected values before parsing
   if (!["start", "stop", "continue"].includes(slurData.type)) {
     throw new Error(`Invalid slur type: ${slurData.type}`);

--- a/src/schemas/notations.ts
+++ b/src/schemas/notations.ts
@@ -8,7 +8,15 @@ export const SlurSchema = z.object({
   type: z.enum(["start", "stop", "continue"]),
   number: z.number().int().optional(), // For nested slurs, default is 1
   placement: z.enum(["above", "below"]).optional(),
-  // TODO: Add other attributes like orientation, color, line-type, bezier-x/y, etc.
+  orientation: z.enum(["over", "under"]).optional(),
+  color: z.string().optional(),
+  lineType: z.string().optional(),
+  bezierX: z.number().optional(),
+  bezierY: z.number().optional(),
+  bezierX2: z.number().optional(),
+  bezierY2: z.number().optional(),
+  bezierOffset: z.number().optional(),
+  bezierOffset2: z.number().optional(),
 });
 export type Slur = z.infer<typeof SlurSchema>;
 

--- a/tests/note.test.ts
+++ b/tests/note.test.ts
@@ -116,6 +116,23 @@ describe("Note Schema Tests (note.mod)", () => {
       expect(slur.placement).toBe("above");
     });
 
+    it("parses slur with orientation, color, line-type, and bezier attributes", () => {
+      const xml =
+        '<note><pitch><step>E</step><octave>4</octave></pitch><duration>4</duration><notations><slur type="start" orientation="over" color="red" line-type="dashed" bezier-x="1" bezier-y="2" bezier-x2="3" bezier-y2="4" bezier-offset="5" bezier-offset2="6"/></notations></note>';
+      const el = createElement(xml);
+      const note = mapNoteElement(el);
+      const slur = note.notations?.slurs?.[0] as Slur;
+      expect(slur.orientation).toBe("over");
+      expect(slur.color).toBe("red");
+      expect(slur.lineType).toBe("dashed");
+      expect(slur.bezierX).toBe(1);
+      expect(slur.bezierY).toBe(2);
+      expect(slur.bezierX2).toBe(3);
+      expect(slur.bezierY2).toBe(4);
+      expect(slur.bezierOffset).toBe(5);
+      expect(slur.bezierOffset2).toBe(6);
+    });
+
     it("should parse a <note> with <accidental>", () => {
       const xml =
         "<note><pitch><step>F</step><alter>1</alter><octave>4</octave></pitch><duration>4</duration><accidental>sharp</accidental></note>";


### PR DESCRIPTION
## Summary
- extend `SlurSchema` with orientation, color, line-type and bezier control points
- map new slur attributes when parsing notes
- test parsing of slurs with extended attributes

## Testing
- `npm run format`
- `npm test`