### PR TITLE
Add beam color attribute

### DIFF
--- a/src/parser/mappers/noteMeasureMappers.ts
+++ b/src/parser/mappers/noteMeasureMappers.ts
@@ -1376,6 +1376,7 @@ const mapBeamElement = (element: Element): Beam | undefined => {
     number: parseOptionalNumberAttribute(element, "number") ?? 1,
     repeater: getAttribute(element, "repeater") as "yes" | "no" | undefined,
     fan: getAttribute(element, "fan") as "accel" | "rit" | "none" | undefined,
+    color: getAttribute(element, "color") || undefined,
   };
   return BeamSchema.parse(beamData);
 };

--- a/src/schemas/beam.ts
+++ b/src/schemas/beam.ts
@@ -34,6 +34,9 @@ export const BeamSchema = z.object({
    * MusicXML 4.0: The fan attribute is used for fanned beams.
    */
   fan: z.enum(["accel", "rit", "none"]).optional(),
-  // TODO: Add color attribute if needed
+  /**
+   * Optional color attribute for coloring beams.
+   */
+  color: z.string().optional(),
 });
 export type Beam = z.infer<typeof BeamSchema>;

--- a/tests/note.test.ts
+++ b/tests/note.test.ts
@@ -102,6 +102,19 @@ describe("Note Schema Tests (note.mod)", () => {
       expect(beam2.value).toBe("begin");
     });
 
+    it('parses a <beam> with color attribute', () => {
+      const xml =
+        '<note><pitch><step>A</step><octave>4</octave></pitch><duration>1</duration><type>16th</type><beam number="1" color="red">begin</beam></note>';
+      const element = createElement(xml);
+      const note = mapNoteElement(element);
+      expect(note.beams).toBeDefined();
+      expect(note.beams).toHaveLength(1);
+      const beam = note.beams?.[0] as Beam;
+      expect(beam.number).toBe(1);
+      expect(beam.value).toBe("begin");
+      expect(beam.color).toBe("red");
+    });
+
     it("should parse a <note> with <notations> and <slur>", () => {
       const xml =
         '<note><pitch><step>D</step><octave>5</octave></pitch><duration>2</duration><notations><slur type="start" number="1" placement="above"/></notations></note>';


### PR DESCRIPTION
## Summary
- add `color` to BeamSchema
- parse beam `color` attribute in `mapNoteElement`
- test that beam color is captured

## Testing
- `npm test`