### PR TITLE
Add accidental attributes support

### DIFF
--- a/src/parser/mappers/noteMeasureMappers.ts
+++ b/src/parser/mappers/noteMeasureMappers.ts
@@ -267,6 +267,12 @@ export const mapAccidentalElement = (element: Element): Accidental => {
     | "yes"
     | "no"
     | undefined;
+  const parentheses = getAttribute(element, "parentheses") as
+    | "yes"
+    | "no"
+    | undefined;
+  const bracket = getAttribute(element, "bracket") as "yes" | "no" | undefined;
+  const size = getAttribute(element, "size") || undefined;
 
   if (!value) {
     throw new Error(
@@ -278,6 +284,9 @@ export const mapAccidentalElement = (element: Element): Accidental => {
     value: value,
     cautionary: cautionary,
     editorial: editorial,
+    parentheses: parentheses,
+    bracket: bracket,
+    size: size,
   };
   return AccidentalSchema.parse(accidentalData);
 };

--- a/src/schemas/accidental.ts
+++ b/src/schemas/accidental.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { YesNoEnum } from "./common";
 
 // Based on MusicXML 4.0 accidental-value simple type
 const AccidentalValueEnum = z.enum([
@@ -62,7 +63,12 @@ export const AccidentalSchema = z.object({
    * Indicates whether the accidental is editorial (e.g., in square brackets).
    */
   editorial: z.enum(["yes", "no"]).optional(),
-  // TODO: Add other attributes like parentheses, bracket, size from MusicXML 4.0 if needed
+  /** Indicates whether the accidental is shown in parentheses. */
+  parentheses: YesNoEnum.optional(),
+  /** Indicates whether the accidental is shown in square brackets. */
+  bracket: YesNoEnum.optional(),
+  /** Size of the accidental, e.g., "cue" or "large". */
+  size: z.string().optional(),
 });
 
 export type Accidental = z.infer<typeof AccidentalSchema>;

--- a/tests/note.test.ts
+++ b/tests/note.test.ts
@@ -126,6 +126,19 @@ describe("Note Schema Tests (note.mod)", () => {
       expect(note.pitch?.alter).toBe(1);
     });
 
+    it("parses accidental attributes parentheses, bracket and size", () => {
+      const xml =
+        '<note><pitch><step>C</step><octave>4</octave></pitch><duration>1</duration><accidental parentheses="yes" bracket="no" size="cue">natural</accidental></note>';
+      const element = createElement(xml);
+      const note = mapNoteElement(element);
+      expect(note.accidental).toBeDefined();
+      const acc = note.accidental!;
+      expect(acc.value).toBe("natural");
+      expect(acc.parentheses).toBe("yes");
+      expect(acc.bracket).toBe("no");
+      expect(acc.size).toBe("cue");
+    });
+
     it("should parse a <note> with <dot>", () => {
       const xml =
         "<note><pitch><step>G</step><octave>4</octave></pitch><duration>3</duration><type>eighth</type><dot/></note>";


### PR DESCRIPTION
## Summary
- allow `AccidentalSchema` to capture parentheses, bracket and size
- parse those attributes in `mapAccidentalElement`
- test accidental attribute handling

## Testing
- `npx vitest run`