### PR TITLE
Handle remaining barline attributes

### DIFF
--- a/src/parser/mappers/noteMeasureMappers.ts
+++ b/src/parser/mappers/noteMeasureMappers.ts
@@ -1055,6 +1055,7 @@ const mapRepeatElement = (element: Element): Repeat => {
       | "double-straight"
       | "double-curved"
       | undefined,
+    afterJump: getAttribute(element, "after-jump") as "yes" | "no" | undefined,
   };
   return RepeatSchema.parse(repeatData);
 };
@@ -1166,6 +1167,8 @@ export const mapBarlineElement = (element: Element): Barline => {
     barlineData.barStyle = barStyleElement.textContent?.trim() as
       | BarStyle
       | undefined;
+    const color = getAttribute(barStyleElement, "color");
+    if (color) barlineData.barStyleColor = color;
   }
   if (repeatElement) {
     barlineData.repeat = mapRepeatElement(repeatElement);

--- a/src/schemas/barline.ts
+++ b/src/schemas/barline.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { FermataSchema } from "./fermata";
 import { WavyLineSchema } from "./wavyLine";
 import { FootnoteSchema, LevelSchema } from "./editorial";
+import { YesNoEnum } from "./common";
 
 /**
  * The bar-style simple type represents the graphic appearance of a barline.
@@ -34,6 +35,8 @@ export const RepeatSchema = z.object({
   winged: z
     .enum(["none", "straight", "curved", "double-straight", "double-curved"])
     .optional(),
+  /** MusicXML 4.0: Indicates if repeats are played after a D.S. or D.C. jump. */
+  afterJump: YesNoEnum.optional(),
 });
 export type Repeat = z.infer<typeof RepeatSchema>;
 
@@ -78,6 +81,8 @@ export const BarlineSchema = z.object({
    * The bar-style element indicates the style of the barline (e.g., heavy, light-light, none).
    */
   barStyle: BarStyleEnum.optional(),
+  /** Optional color attribute for the bar-style element. */
+  barStyleColor: z.string().optional(),
   /**
    * The repeat element indicates a repeat mark.
    */

--- a/tests/barline.test.ts
+++ b/tests/barline.test.ts
@@ -22,13 +22,14 @@ function createElement(xmlString: string): Element {
 describe("Barline Schema Tests", () => {
   describe("mapBarlineElement", () => {
     it("should parse a basic <barline> element with <bar-style>", () => {
-      const xml = `<barline location="right"><bar-style>light-heavy</bar-style></barline>`;
+      const xml = `<barline location="right"><bar-style color="#000000">light-heavy</bar-style></barline>`;
       const element = createElement(xml);
       const barline = mapBarlineElement(element);
       expect(barline).toBeDefined();
       expect(barline._type).toBe("barline");
       expect(barline.location).toBe("right");
       expect(barline.barStyle).toBe("light-heavy");
+      expect(barline.barStyleColor).toBe("#000000");
     });
 
     it('should parse <barline> with <repeat direction="forward">', () => {
@@ -48,6 +49,15 @@ describe("Barline Schema Tests", () => {
       const repeat = barline.repeat as Repeat;
       expect(repeat.direction).toBe("backward");
       expect(repeat.times).toBe(2);
+    });
+
+    it('should parse repeat attributes winged and after-jump', () => {
+      const xml = `<barline><repeat direction="backward" winged="curved" after-jump="yes"/></barline>`;
+      const element = createElement(xml);
+      const barline = mapBarlineElement(element);
+      const repeat = barline.repeat as Repeat;
+      expect(repeat.winged).toBe("curved");
+      expect(repeat.afterJump).toBe("yes");
     });
 
     it('should parse <barline> with <ending type="start" number="1">', () => {


### PR DESCRIPTION
## Summary
- parse `after-jump` in repeat elements
- read the colour attribute on `bar-style`
- test new repeat and bar-style properties

## Testing
- `npm test`
- `npm run build`
