### PR TITLE
Implement slash-type parsing

### DIFF
--- a/src/parser/mappers/noteMeasureMappers.ts
+++ b/src/parser/mappers/noteMeasureMappers.ts
@@ -1702,8 +1702,16 @@ const mapBeatRepeatElement = (element: Element): BeatRepeat | undefined => {
     slashes: parseOptionalNumberAttribute(element, "slashes"),
     useDots: getAttribute(element, "use-dots") as "yes" | "no" | undefined,
     slashType: getTextContent(element, "slash-type"),
-    // slashDot: ...
-    // exceptVoice: ...
+    slashDot:
+      element.querySelectorAll("slash-dot").length > 0
+        ? Array.from(element.querySelectorAll("slash-dot")).map(() => ({}))
+        : undefined,
+    exceptVoice:
+      element.querySelectorAll("except-voice").length > 0
+        ? Array.from(element.querySelectorAll("except-voice"))
+            .map((el) => el.textContent?.trim())
+            .filter((v): v is string => !!v)
+        : undefined,
   };
   try {
     return BeatRepeatSchema.parse(data);
@@ -1726,8 +1734,16 @@ const mapSlashElement = (element: Element): Slash | undefined => {
     useDots: getAttribute(element, "use-dots") as "yes" | "no" | undefined,
     useStems: getAttribute(element, "use-stems") as "yes" | "no" | undefined,
     slashType: getTextContent(element, "slash-type"),
-    // slashDot: ...
-    // exceptVoice: ...
+    slashDot:
+      element.querySelectorAll("slash-dot").length > 0
+        ? Array.from(element.querySelectorAll("slash-dot")).map(() => ({}))
+        : undefined,
+    exceptVoice:
+      element.querySelectorAll("except-voice").length > 0
+        ? Array.from(element.querySelectorAll("except-voice"))
+            .map((el) => el.textContent?.trim())
+            .filter((v): v is string => !!v)
+        : undefined,
   };
   try {
     return SlashSchema.parse(data);

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -32,6 +32,7 @@ export * from "./partGroup";
 export * from "./grace";
 export * from "./cue";
 export * from "./unpitched";
+export * from "./noteType";
 export * from "./defaults";
 export * from "./credit";
 export * from "./harmony";

--- a/src/schemas/measureStyle.ts
+++ b/src/schemas/measureStyle.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { YesNoEnum } from "./common";
+import { NoteTypeValueEnum } from "./noteType";
 
 /**
  * The multiple-rest element is used to indicate a multi-measure rest.
@@ -16,12 +17,14 @@ export const MeasureRepeatSchema = z.object({
   slashes: z.number().int().optional(),
 });
 
+export const SlashDotSchema = z.object({});
+
 export const BeatRepeatSchema = z.object({
   type: z.enum(["start", "stop"]),
   slashes: z.number().int().optional(),
   useDots: YesNoEnum.optional(),
-  slashType: z.string().optional(), // Placeholder
-  slashDot: z.array(z.object({})).optional(), // Placeholder for empty <slash-dot/>
+  slashType: NoteTypeValueEnum.optional(),
+  slashDot: z.array(SlashDotSchema).optional(),
   exceptVoice: z.array(z.string()).optional(), // PCDATA
 });
 
@@ -29,8 +32,8 @@ export const SlashSchema = z.object({
   type: z.enum(["start", "stop"]),
   useDots: YesNoEnum.optional(),
   useStems: YesNoEnum.optional(),
-  slashType: z.string().optional(), // Placeholder
-  slashDot: z.array(z.object({})).optional(), // Placeholder for empty <slash-dot/>
+  slashType: NoteTypeValueEnum.optional(),
+  slashDot: z.array(SlashDotSchema).optional(),
   exceptVoice: z.array(z.string()).optional(), // PCDATA
 });
 

--- a/src/schemas/noteType.ts
+++ b/src/schemas/noteType.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+/**
+ * The note-type-value enumeration as defined by MusicXML. This represents
+ * the graphical note type from shortest to longest duration.
+ */
+export const NoteTypeValueEnum = z.enum([
+  "1024th",
+  "512th",
+  "256th",
+  "128th",
+  "64th",
+  "32nd",
+  "16th",
+  "eighth",
+  "quarter",
+  "half",
+  "whole",
+  "breve",
+  "long",
+  "maxima",
+]);
+
+export type NoteTypeValue = z.infer<typeof NoteTypeValueEnum>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -90,6 +90,7 @@ export type {
   DisplayStep,
   DisplayOctave,
 } from "../schemas/unpitched";
+export type { NoteTypeValue } from "../schemas/noteType";
 export type {
   YesNo,
   Font,

--- a/tests/attributes.test.ts
+++ b/tests/attributes.test.ts
@@ -184,6 +184,26 @@ describe("Attributes Schema Tests", () => {
       expect(sl.slashType).toBe("eighth");
     });
 
+    it("should parse beat-repeat with slash-dot elements", () => {
+      const xml = `<attributes><measure-style><beat-repeat type="start"><slash-type>quarter</slash-type><slash-dot/><slash-dot/></beat-repeat></measure-style></attributes>`;
+      const element = createElement(xml);
+      const attributes = mapAttributesElement(element);
+      const br = (attributes.measureStyle?.[0] as MeasureStyle).beatRepeat as BeatRepeat;
+      expect(br.slashType).toBe("quarter");
+      expect(br.slashDot).toBeDefined();
+      expect(br.slashDot?.length).toBe(2);
+    });
+
+    it("should parse slash style with slash-dot elements", () => {
+      const xml = `<attributes><measure-style><slash type="stop"><slash-type>eighth</slash-type><slash-dot/></slash></measure-style></attributes>`;
+      const element = createElement(xml);
+      const attributes = mapAttributesElement(element);
+      const sl = (attributes.measureStyle?.[0] as MeasureStyle).slash as Slash;
+      expect(sl.slashType).toBe("eighth");
+      expect(sl.slashDot).toBeDefined();
+      expect(sl.slashDot?.length).toBe(1);
+    });
+
     it("should ignore invalid <measure-style> with no style child", () => {
       const xml = `<attributes><measure-style number="1"></measure-style></attributes>`;
       const element = createElement(xml);


### PR DESCRIPTION
## Summary
- define `NoteTypeValue` enumeration
- add real `slashType` and `slashDot` schemas for measure style
- parse slash-dot and except-voice elements in mappers
- export new enum in public types
- test measure-style parsing with slash-dot

## Testing
- `npm test`