### PR TITLE
Add instruments field and transpose array support

### DIFF
--- a/src/parser/mappers/noteMeasureMappers.ts
+++ b/src/parser/mappers/noteMeasureMappers.ts
@@ -1801,7 +1801,8 @@ export const mapAttributesElement = (element: Element): Attributes => {
   const clefElements = Array.from(element.querySelectorAll("clef"));
   const stavesContent = getTextContent(element, "staves"); // Read content of <staves>
   const partSymbolElement = element.querySelector("part-symbol");
-  const transposeElement = element.querySelector("transpose");
+  const transposeElements = Array.from(element.querySelectorAll("transpose"));
+  const instrumentsContent = getTextContent(element, "instruments");
   const staffDetailsElements = Array.from(
     element.querySelectorAll("staff-details"),
   );
@@ -1844,9 +1845,18 @@ export const mapAttributesElement = (element: Element): Attributes => {
     if (mappedPartSymbol) attributesData.partSymbol = mappedPartSymbol;
   }
 
-  if (transposeElement) {
-    const mappedTranspose = mapTransposeElement(transposeElement);
-    if (mappedTranspose) attributesData.transpose = mappedTranspose;
+  if (transposeElements.length > 0) {
+    const mappedTranspose = transposeElements
+      .map(mapTransposeElement)
+      .filter(Boolean) as Transpose[];
+    if (mappedTranspose.length > 0) attributesData.transpose = mappedTranspose;
+  }
+
+  if (instrumentsContent !== undefined) {
+    const instNum = parseInt(instrumentsContent, 10);
+    if (!isNaN(instNum)) {
+      attributesData.instruments = instNum;
+    }
   }
 
   if (staffDetailsElements.length > 0) {

--- a/src/schemas/attributes.ts
+++ b/src/schemas/attributes.ts
@@ -13,12 +13,13 @@ export const AttributesSchema = z.object({
   key: z.array(KeySchema).optional(), // <key> can appear multiple times for different staves, though often once
   time: z.array(TimeSchema).optional(), // <time> can appear multiple times
   clef: z.array(ClefSchema).optional(), // <clef> can appear multiple times
-  transpose: TransposeSchema.optional(),
+  transpose: z.array(TransposeSchema).optional(),
+  instruments: z.number().int().positive().optional(),
   staves: z.number().int().positive().optional(),
   staffDetails: z.array(StaffDetailsSchema).optional(),
   measureStyle: z.array(MeasureStyleSchema).optional(),
   partSymbol: PartSymbolSchema.optional(),
-  // Placeholder for other attributes like <staves>, <part-symbol>, <transpose>, etc.
+  // Placeholder for other attributes like <for-part> etc.
 });
 
 export type Attributes = z.infer<typeof AttributesSchema>;

--- a/tests/attributes.test.ts
+++ b/tests/attributes.test.ts
@@ -120,7 +120,26 @@ describe("Attributes Schema Tests", () => {
       expect(ps.topStaff).toBe(3);
     });
 
-    // TODO: Add tests for instruments when schema is available
+    it("should parse <instruments> count", () => {
+      const xml = `<attributes><instruments>5</instruments></attributes>`;
+      const element = createElement(xml);
+      const attributes = mapAttributesElement(element);
+      expect(attributes.instruments).toBe(5);
+    });
+
+    it("should parse <transpose> with details", () => {
+      const xml = `<attributes><transpose number="1"><diatonic>-2</diatonic><chromatic>-3</chromatic><octave-change>1</octave-change><double above="yes"/></transpose></attributes>`;
+      const element = createElement(xml);
+      const attributes = mapAttributesElement(element);
+      expect(attributes.transpose).toBeDefined();
+      expect(attributes.transpose?.length).toBe(1);
+      const tr = attributes.transpose?.[0]!;
+      expect(tr.number).toBe(1);
+      expect(tr.diatonic).toBe(-2);
+      expect(tr.chromatic).toBe(-3);
+      expect(tr.octaveChange).toBe(1);
+      expect(tr.double?.above).toBe("yes");
+    });
 
     it("should parse <staff-details> with <line-detail>", () => {
       const xml = `<attributes><staff-details><staff-lines>5</staff-lines><line-detail line="1" width="0.5" color="#ff0" line-type="dashed" print-object="no"/></staff-details></attributes>`;

--- a/tests/xmlsamples.test.ts
+++ b/tests/xmlsamples.test.ts
@@ -77,12 +77,16 @@ describe("Specific feature checks from samples", () => {
     if (!xmlDoc) throw new Error("MozartTrio.musicxml failed to parse");
     const score = mapDocumentToScorePartwise(xmlDoc);
     const measureWithTranspose = score.parts[0].measures.find((m: Measure) =>
-      getAttributesFromContent(m.content).some((a: Attributes) => a.transpose),
+      getAttributesFromContent(m.content).some(
+        (a: Attributes) => a.transpose && a.transpose.length > 0,
+      ),
     );
     expect(measureWithTranspose).toBeDefined();
     const transpose = getAttributesFromContent(
       measureWithTranspose!.content,
-    ).find((a) => a.transpose)?.transpose;
+    )
+      .find((a) => a.transpose && a.transpose.length > 0)!
+      .transpose?.[0];
     expect(transpose?.chromatic).toBe(-3);
   });
 


### PR DESCRIPTION
## Summary
- extend `AttributesSchema` with `instruments` and allow multiple `transpose` entries
- parse `instruments` and handle multiple `<transpose>` in `mapAttributesElement`
- update XML sample test to handle array form
- add unit tests for instruments and transpose details

## Testing
- `npm test`