### PR TITLE
Implement instruments attribute parsing

### DIFF
--- a/reference/instruments/InstrumentsSample.musicxml
+++ b/reference/instruments/InstrumentsSample.musicxml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <part-list>
+    <score-part id="P1">
+      <part-name>Instrument Test</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <instruments>2</instruments>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1</duration>
+        <type>quarter</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/src/parser/mappers/noteMeasureMappers.ts
+++ b/src/parser/mappers/noteMeasureMappers.ts
@@ -1800,6 +1800,7 @@ export const mapAttributesElement = (element: Element): Attributes => {
   const timeElements = Array.from(element.querySelectorAll("time"));
   const clefElements = Array.from(element.querySelectorAll("clef"));
   const stavesContent = getTextContent(element, "staves"); // Read content of <staves>
+  const instrumentsContent = getTextContent(element, "instruments");
   const partSymbolElement = element.querySelector("part-symbol");
   const transposeElement = element.querySelector("transpose");
   const staffDetailsElements = Array.from(
@@ -1836,6 +1837,13 @@ export const mapAttributesElement = (element: Element): Attributes => {
     const stavesNum = parseInt(stavesContent, 10);
     if (!isNaN(stavesNum)) {
       attributesData.staves = stavesNum;
+    }
+  }
+
+  if (instrumentsContent !== undefined) {
+    const instrNum = parseInt(instrumentsContent, 10);
+    if (!isNaN(instrNum)) {
+      attributesData.instruments = instrNum;
     }
   }
 

--- a/src/schemas/attributes.ts
+++ b/src/schemas/attributes.ts
@@ -15,6 +15,8 @@ export const AttributesSchema = z.object({
   clef: z.array(ClefSchema).optional(), // <clef> can appear multiple times
   transpose: TransposeSchema.optional(),
   staves: z.number().int().positive().optional(),
+  /** Number of instruments represented in the part */
+  instruments: z.number().int().positive().optional(),
   staffDetails: z.array(StaffDetailsSchema).optional(),
   measureStyle: z.array(MeasureStyleSchema).optional(),
   partSymbol: PartSymbolSchema.optional(),

--- a/tests/attributes.test.ts
+++ b/tests/attributes.test.ts
@@ -120,7 +120,12 @@ describe("Attributes Schema Tests", () => {
       expect(ps.topStaff).toBe(3);
     });
 
-    // TODO: Add tests for instruments when schema is available
+    it("should parse <attributes> with <instruments>", () => {
+      const xml = `<attributes><instruments>2</instruments></attributes>`;
+      const element = createElement(xml);
+      const attributes = mapAttributesElement(element);
+      expect(attributes.instruments).toBe(2);
+    });
 
     it("should parse <staff-details> with <line-detail>", () => {
       const xml = `<attributes><staff-details><staff-lines>5</staff-lines><line-detail line="1" width="0.5" color="#ff0" line-type="dashed" print-object="no"/></staff-details></attributes>`;


### PR DESCRIPTION
## Summary
- expand attributes schema with `instruments`
- map `<instruments>` elements in attributes parser
- test instruments parsing
- add MusicXML reference sample with instruments

## Testing
- `npm test`