### PR TITLE
Add basic conversion utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,19 @@ if (doc) {
 }
 ```
 
+### Conversion Utilities
+
+Once you have a `ScorePartwise` object you can convert it into other formats:
+
+```typescript
+import { toMusicJson, toYaml, toToneJsSequence, toMidi } from 'your-musicxml-parser-package-name';
+
+const json = toMusicJson(score);
+const yamlString = toYaml(score);
+const toneSeq = toToneJsSequence(score);
+const midi = toMidi(score);
+```
+
 ## Project Structure
 
 *   `src/`: Source code

--- a/src/converters/index.ts
+++ b/src/converters/index.ts
@@ -1,0 +1,4 @@
+export * from "./toMusicJson";
+export * from "./toYaml";
+export * from "./toToneJsSequence";
+export * from "./toMidi";

--- a/src/converters/toMidi.ts
+++ b/src/converters/toMidi.ts
@@ -1,0 +1,36 @@
+import type { ScorePartwise } from "../types";
+import { toToneJsSequence } from "./toToneJsSequence";
+
+export interface MidiHeader {
+  format: number;
+  numTracks: number;
+  ticksPerBeat: number;
+}
+
+export interface MidiNote {
+  time: number;
+  duration: number;
+  midi: number;
+}
+
+export interface MidiData {
+  header: MidiHeader;
+  tracks: MidiNote[];
+}
+
+/**
+ * Convert a ScorePartwise object to a very simple MIDI-like data structure.
+ * This does not produce a binary MIDI file but returns note data that can be
+ * fed into a MIDI library.
+ */
+export function toMidi(score: ScorePartwise): MidiData {
+  const sequence = toToneJsSequence(score);
+  return {
+    header: {
+      format: 1,
+      numTracks: 1,
+      ticksPerBeat: 480,
+    },
+    tracks: sequence.notes,
+  };
+}

--- a/src/converters/toMusicJson.ts
+++ b/src/converters/toMusicJson.ts
@@ -1,0 +1,6 @@
+import type { ScorePartwise } from "../types";
+
+/** Convert a ScorePartwise object to a pretty JSON string. */
+export function toMusicJson(score: ScorePartwise): string {
+  return JSON.stringify(score, null, 2);
+}

--- a/src/converters/toToneJsSequence.ts
+++ b/src/converters/toToneJsSequence.ts
@@ -1,0 +1,55 @@
+import type { ScorePartwise, Note, MeasureContent } from "../types";
+
+export interface ToneJsNote {
+  time: number;
+  duration: number;
+  midi: number;
+}
+
+export interface ToneJsSequence {
+  notes: ToneJsNote[];
+}
+
+/**
+ * Convert a ScorePartwise object to a minimal Tone.js-like sequence.
+ * The conversion is simplistic and only interprets pitched notes.
+ */
+export function toToneJsSequence(score: ScorePartwise): ToneJsSequence {
+  const notes: ToneJsNote[] = [];
+  const stepToSemitone: Record<string, number> = {
+    C: 0,
+    D: 2,
+    E: 4,
+    F: 5,
+    G: 7,
+    A: 9,
+    B: 11,
+  };
+
+  let time = 0;
+  const isNote = (mc: MeasureContent): mc is Note =>
+    (mc as Note)._type === "note";
+
+  for (const part of score.parts) {
+    for (const measure of part.measures) {
+      for (const item of measure.content ?? []) {
+        if (isNote(item)) {
+          if (item.pitch) {
+            const step = item.pitch.step;
+            const octave = item.pitch.octave;
+            const alter = item.pitch.alter ?? 0;
+            const midi = (octave + 1) * 12 + stepToSemitone[step] + alter;
+            const duration = item.duration ?? 1;
+            notes.push({ time, duration, midi });
+            time += duration;
+          } else if (item.rest) {
+            const restDuration = item.duration ?? 1;
+            time += restDuration;
+          }
+        }
+      }
+    }
+  }
+
+  return { notes };
+}

--- a/src/converters/toYaml.ts
+++ b/src/converters/toYaml.ts
@@ -1,0 +1,7 @@
+import type { ScorePartwise } from "../types";
+import { dump } from "js-yaml";
+
+/** Convert a ScorePartwise object to a YAML string. */
+export function toYaml(score: ScorePartwise): string {
+  return dump(score);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./parser";
 export * from "./schemas";
 export * from "./types"; // Zodから推論される型などをエクスポートするため
+export * from "./converters";

--- a/src/types/js-yaml.d.ts
+++ b/src/types/js-yaml.d.ts
@@ -1,0 +1,4 @@
+declare module "js-yaml" {
+  export function dump(obj: unknown, options?: unknown): string;
+  export function load(str: string): unknown;
+}

--- a/tests/converters.test.ts
+++ b/tests/converters.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { parseMusicXmlString } from "../src/parser/xmlParser";
+import { mapDocumentToScorePartwise } from "../src/parser/mappers";
+import {
+  toMusicJson,
+  toYaml,
+  toToneJsSequence,
+  toMidi,
+} from "../src/converters";
+import { load } from "js-yaml";
+
+const xml = `
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1">
+      <part-name>Music</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1</duration>
+        <type>quarter</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+
+describe("Conversion utilities", () => {
+  it("serializes to JSON and YAML", async () => {
+    const doc = await parseMusicXmlString(xml);
+    if (!doc) throw new Error("parse failed");
+    const score = mapDocumentToScorePartwise(doc);
+    const json = toMusicJson(score);
+    expect(JSON.parse(json)).toEqual(score);
+    const yamlStr = toYaml(score);
+    const obj = load(yamlStr);
+    expect(obj).toEqual(JSON.parse(json));
+  });
+
+  it("creates Tone.js sequence and MIDI data", async () => {
+    const doc = await parseMusicXmlString(xml);
+    if (!doc) throw new Error("parse failed");
+    const score = mapDocumentToScorePartwise(doc);
+    const seq = toToneJsSequence(score);
+    expect(seq.notes.length).toBe(1);
+    expect(seq.notes[0].midi).toBe(60);
+    const midi = toMidi(score);
+    expect(midi.tracks.length).toBe(1);
+    expect(midi.tracks[0].midi).toBe(60);
+  });
+});


### PR DESCRIPTION
## Summary
- add converters for MusicJSON, YAML, Tone.js sequence and MIDI
- document conversion usage
- export converters in package
- provide unit tests for conversion functions

## Testing
- `npm run format`
- `npm run lint`
- `npm run type-check`
- `npm test`