### PR TITLE
Implement full tie handling and complete barline parser

### DIFF
--- a/src/parser/mappers/noteMeasureMappers.ts
+++ b/src/parser/mappers/noteMeasureMappers.ts
@@ -480,16 +480,7 @@ export const mapNoteElement = (element: Element): Note => {
   }
 
   if (tieElements.length > 0) {
-    // Assuming TieSchema and mapTieElement exist and handle the 'type' attribute
-    // For now, storing them as simple objects if mapTieElement is not defined
-    noteData.ties = tieElements
-      .map((el) => ({
-        type: getAttribute(el, "type") as "start" | "stop" | undefined,
-      }))
-      .filter((t) => t.type) as { type: "start" | "stop" }[];
-    // This needs to be mapTieElement if complex tie objects are needed.
-    // For now, it's a simplified placeholder.
-    // Example: noteData.ties = tieElements.map(mapTieElement).filter(Boolean) as Tie[];
+    noteData.ties = tieElements.map(mapTieElement);
   }
 
   if (dotElements.length > 0) {
@@ -715,6 +706,15 @@ const mapTiedElement = (element: Element): Tie => {
   const type = getAttribute(element, "type") as "start" | "stop" | undefined;
   if (!type) {
     throw new Error('<tied> element requires a "type" attribute.');
+  }
+  return TieSchema.parse({ type });
+};
+
+// Helper to map a <tie> element
+const mapTieElement = (element: Element): Tie => {
+  const type = getAttribute(element, "type") as "start" | "stop" | undefined;
+  if (!type) {
+    throw new Error('<tie> element requires a "type" attribute.');
   }
   return TieSchema.parse({ type });
 };
@@ -1301,7 +1301,6 @@ export const mapBarlineElement = (element: Element): Barline => {
   }
   const idAttr = getAttribute(element, "id");
   if (idAttr) barlineData.id = idAttr;
-  // TODO: Parse other barline children and attributes
 
   return BarlineSchema.parse(barlineData);
 };

--- a/tests/barline.test.ts
+++ b/tests/barline.test.ts
@@ -120,6 +120,20 @@ describe("Barline Schema Tests", () => {
       expect(wavy.number).toBe(2);
     });
 
+    it("parses wavy-line attributes", () => {
+      const xml = `<barline><wavy-line type="start" accelerate="yes" beats="3" second-beats="2" last-beat="4" placement="above" color="#123456"/></barline>`;
+      const element = createElement(xml);
+      const barline = mapBarlineElement(element);
+      const wavy = barline.wavyLine as WavyLine;
+      expect(wavy.type).toBe("start");
+      expect(wavy.accelerate).toBe("yes");
+      expect(wavy.beats).toBe(3);
+      expect(wavy.secondBeats).toBe(2);
+      expect(wavy.lastBeat).toBe(4);
+      expect(wavy.placement).toBe("above");
+      expect(wavy.color).toBe("#123456");
+    });
+
     it("should parse footnote and level elements", () => {
       const xml = `<barline><footnote>ref</footnote><level reference="yes" parentheses="yes">ed</level></barline>`;
       const element = createElement(xml);

--- a/tests/note.test.ts
+++ b/tests/note.test.ts
@@ -279,6 +279,12 @@ describe("Note Schema Tests (note.mod)", () => {
       expect(t2.type).toBe("stop");
     });
 
+    it("throws on tie without type attribute", () => {
+      const xml = '<note><pitch><step>C</step><octave>4</octave></pitch><duration>4</duration><tie/></note>';
+      const element = createElement(xml);
+      expect(() => mapNoteElement(element)).toThrow();
+    });
+
     it("parses minimal <time-modification>", () => {
       const xml =
         "<note><pitch><step>A</step><octave>4</octave></pitch><duration>2</duration><time-modification><actual-notes>5</actual-notes><normal-notes>4</normal-notes></time-modification></note>";


### PR DESCRIPTION
## Summary
- add `mapTieElement` implementation
- parse tie elements in notes with `mapTieElement`
- remove obsolete TODO in barline mapper
- extend barline tests for wavy-line attributes
- add test for invalid tie without type attribute

## Testing
- `npm test`