### PR TITLE
Add MXL reading helper and extend tests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export * from "./parser";
 export * from "./schemas";
 export * from "./types"; // Zodから推論される型などをエクスポートするため
 export * from "./converters";
+export * from "./utils/readMusicXmlFile";

--- a/src/utils/readMusicXmlFile.ts
+++ b/src/utils/readMusicXmlFile.ts
@@ -1,0 +1,69 @@
+import { promises as fs } from "fs";
+import { execFile } from "child_process";
+import { promisify } from "util";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Read a MusicXML or MXL file and return its XML contents as a UTF-8 string.
+ * The function checks the XML prolog for an encoding declaration and converts
+ * UTF-16 files to UTF-8.
+ *
+ * For `.mxl` archives this implementation relies on the system `unzip` command
+ * to extract the first `*.musicxml` entry.
+ */
+export async function readMusicXmlFile(filePath: string): Promise<string> {
+  let data: Buffer;
+
+  if (filePath.toLowerCase().endsWith(".mxl")) {
+    const { stdout } = await execFileAsync(
+      "unzip",
+      ["-p", filePath, "*.musicxml"],
+      { maxBuffer: 10 * 1024 * 1024, encoding: "buffer" },
+    );
+    data = stdout as Buffer;
+  } else {
+    data = await fs.readFile(filePath);
+  }
+
+  let encoding = "UTF-8";
+  if (data.length >= 2) {
+    const b0 = data[0];
+    const b1 = data[1];
+    if (b0 === 0xfe && b1 === 0xff) {
+      encoding = "UTF-16BE";
+    } else if (b0 === 0xff && b1 === 0xfe) {
+      encoding = "UTF-16LE";
+    } else if (data.length >= 3 && b0 === 0xef && b1 === 0xbb && data[2] === 0xbf) {
+      encoding = "UTF-8";
+    }
+  }
+  const prolog = data.slice(0, 100).toString("ascii").replace(/\0/g, "");
+  const encMatch = prolog.match(/encoding=\"([^\"]+)\"/i);
+  if (encMatch) {
+    const declared = encMatch[1].toUpperCase();
+    if (declared !== "UTF-16") {
+      encoding = declared;
+    }
+    // if declared is UTF-16, prefer BOM-detected endianness
+  }
+
+  let xml: string;
+  if (encoding === "UTF-16" || encoding === "UTF-16LE") {
+    xml = data.toString("utf16le");
+  } else if (encoding === "UTF-16BE") {
+    const swapped = Buffer.allocUnsafe(data.length);
+    for (let i = 0; i < data.length; i += 2) {
+      swapped[i] = data[i + 1];
+      swapped[i + 1] = data[i];
+    }
+    xml = swapped.toString("utf16le");
+  } else {
+    xml = data.toString("utf8");
+  }
+
+  if (xml.charCodeAt(0) === 0xfeff) {
+    xml = xml.slice(1);
+  }
+  return xml;
+}

--- a/tests/xmlsamples.test.ts
+++ b/tests/xmlsamples.test.ts
@@ -5,15 +5,12 @@ import { parseMusicXmlString } from "../src/parser/xmlParser";
 import { mapDocumentToScorePartwise } from "../src/parser/mappers";
 import type { Measure, Note, Attributes } from "../src/types";
 import { NoteSchema, AttributesSchema } from "../src/schemas";
+import { readMusicXmlFile } from "../src/utils/readMusicXmlFile";
 
 const samplesDir = path.resolve(__dirname, "../reference/xmlsamples");
 const sampleFiles = fs
   .readdirSync(samplesDir)
-  .filter(
-    (f) =>
-      f.endsWith(".musicxml") &&
-      !["MozaChloSample.musicxml", "MozaVeilSample.musicxml"].includes(f),
-  );
+  .filter((f) => /\.(musicxml|mxl)$/.test(f));
 
 function getNotesFromContent(content: Measure["content"] | undefined): Note[] {
   if (!content) return [];
@@ -37,7 +34,7 @@ function getAttributesFromContent(
 describe("Reference MusicXML sample parsing", () => {
   for (const file of sampleFiles) {
     it(`parses ${file} without mapping errors`, async () => {
-      const xmlString = fs.readFileSync(path.join(samplesDir, file), "utf-8");
+      const xmlString = await readMusicXmlFile(path.join(samplesDir, file));
       const xmlDoc = await parseMusicXmlString(xmlString);
       expect(xmlDoc).not.toBeNull();
       if (!xmlDoc) return;
@@ -52,9 +49,8 @@ describe("Reference MusicXML sample parsing", () => {
 
 describe("Specific feature checks from samples", () => {
   it("Saltarello.musicxml contains slur notation", async () => {
-    const xmlString = fs.readFileSync(
+    const xmlString = await readMusicXmlFile(
       path.join(samplesDir, "Saltarello.musicxml"),
-      "utf-8",
     );
     const xmlDoc = await parseMusicXmlString(xmlString);
     if (!xmlDoc) throw new Error("Saltarello.musicxml failed to parse");
@@ -69,9 +65,8 @@ describe("Specific feature checks from samples", () => {
   });
 
   it("MozartTrio.musicxml contains transpose information", async () => {
-    const xmlString = fs.readFileSync(
+    const xmlString = await readMusicXmlFile(
       path.join(samplesDir, "MozartTrio.musicxml"),
-      "utf-8",
     );
     const xmlDoc = await parseMusicXmlString(xmlString);
     if (!xmlDoc) throw new Error("MozartTrio.musicxml failed to parse");
@@ -89,9 +84,8 @@ describe("Specific feature checks from samples", () => {
   });
 
   it("DebuMandSample.musicxml maps staccato articulations", async () => {
-    const xmlString = fs.readFileSync(
+    const xmlString = await readMusicXmlFile(
       path.join(samplesDir, "DebuMandSample.musicxml"),
-      "utf-8",
     );
     const xmlDoc = await parseMusicXmlString(xmlString);
     if (!xmlDoc) throw new Error("DebuMandSample.musicxml failed to parse");
@@ -105,9 +99,8 @@ describe("Specific feature checks from samples", () => {
   });
 
   it("ActorPreludeSample.musicxml captures staff-layout defaults", async () => {
-    const xmlString = fs.readFileSync(
+    const xmlString = await readMusicXmlFile(
       path.join(samplesDir, "ActorPreludeSample.musicxml"),
-      "utf-8",
     );
     const xmlDoc = await parseMusicXmlString(xmlString);
     if (!xmlDoc) throw new Error("ActorPreludeSample.musicxml failed to parse");


### PR DESCRIPTION
## Summary
- add `readMusicXmlFile` helper to detect encoding and handle `.mxl`
- export helper from library
- use helper in xml sample tests and include `.mxl` samples

## Testing
- `npm test`