### PR TITLE
Add multi-part MusicXML sample and test

### DIFF
--- a/reference/xmlsamples/MultiPartGroup.musicxml
+++ b/reference/xmlsamples/MultiPartGroup.musicxml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <part-list>
+    <part-group number="1" type="start">
+      <group-name>Strings</group-name>
+    </part-group>
+    <score-part id="P1">
+      <part-name>Violin</part-name>
+    </score-part>
+    <score-part id="P2">
+      <part-name>Cello</part-name>
+    </score-part>
+    <part-group number="1" type="stop"/>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <type>whole</type>
+      </note>
+    </measure>
+  </part>
+  <part id="P2">
+    <measure number="1">
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>4</duration>
+        <type>whole</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/tests/multiPart.test.ts
+++ b/tests/multiPart.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import { parseMusicXmlString } from "../src/parser/xmlParser";
+import { mapDocumentToScorePartwise } from "../src/parser/mappers";
+
+const filePath = path.resolve(
+  __dirname,
+  "../reference/xmlsamples/MultiPartGroup.musicxml",
+);
+
+describe("Multi-part score with group", () => {
+  it("parses parts and part-list correctly", async () => {
+    const xmlString = fs.readFileSync(filePath, "utf-8");
+    const doc = await parseMusicXmlString(xmlString);
+    expect(doc).not.toBeNull();
+    if (!doc) return;
+    const score = mapDocumentToScorePartwise(doc);
+
+    // two parts present
+    expect(score.parts.length).toBe(2);
+    expect(score.parts[0].id).toBe("P1");
+    expect(score.parts[1].id).toBe("P2");
+
+    // part-list contains group and score-parts
+    expect(score.partList.scoreParts.length).toBe(2);
+    expect(score.partList.partGroups?.length).toBe(2);
+    expect(score.partList.partGroups?.[0].type).toBe("start");
+    expect(score.partList.partGroups?.[0].groupName).toBe("Strings");
+    expect(score.partList.partGroups?.[1].type).toBe("stop");
+
+    // measures read correctly
+    expect(score.parts[0].measures.length).toBe(1);
+    expect(score.parts[0].measures[0].number).toBe("1");
+    expect(score.parts[1].measures.length).toBe(1);
+    expect(score.parts[1].measures[0].number).toBe("1");
+  });
+});


### PR DESCRIPTION
## Summary
- include a new simple MusicXML score with two parts and a part-group
- add a unit test that parses this file and verifies part list, group and measures

## Testing
- `npm test`