### PR TITLE
Add multi-voice measure test

### DIFF
--- a/src/parser/mappers/noteMeasureMappers.ts
+++ b/src/parser/mappers/noteMeasureMappers.ts
@@ -442,6 +442,7 @@ export const mapNoteElement = (element: Element): Note => {
   const lyricElements = Array.from(element.querySelectorAll("lyric"));
   const tieElements = Array.from(element.querySelectorAll("tie"));
   const timeModElement = element.querySelector("time-modification");
+  const voiceContent = getTextContent(element, "voice");
 
   const noteData: Partial<Note> = {
     _type: "note",
@@ -518,6 +519,9 @@ export const mapNoteElement = (element: Element): Note => {
   }
   if (lyricElements.length > 0) {
     noteData.lyrics = lyricElements.map(mapLyricElement);
+  }
+  if (voiceContent) {
+    noteData.voice = voiceContent;
   }
 
   try {

--- a/src/schemas/note.ts
+++ b/src/schemas/note.ts
@@ -29,6 +29,7 @@ export const NoteSchema = z
     duration: z.number().int().optional(),
     timeModification: TimeModificationSchema.optional(),
     ties: z.array(TieSchema).max(2).optional(),
+    voice: z.string().optional(),
     type: z.string().optional(),
     dots: z.array(z.object({})).optional(),
     accidental: AccidentalSchema.optional(),


### PR DESCRIPTION
## Summary
- support `voice` on notes
- parse `voice` element in note mapper
- add test covering multi-voice measure with `<backup>` and `<forward>`

## Testing
- `npm test`