### PR TITLE
Add offset and sound parsing for direction

### DIFF
--- a/src/parser/mappers/noteMeasureMappers.ts
+++ b/src/parser/mappers/noteMeasureMappers.ts
@@ -1325,6 +1325,8 @@ export const mapDirectionElement = (element: Element): Direction => {
     | "yes"
     | "no"
     | undefined;
+  const offsetVal = parseFloatContent(element, "offset");
+  const soundEl = element.querySelector("sound");
   const directionData: Partial<Direction> = {
     _type: "direction",
     direction_type: directionTypeElements.map(mapDirectionTypeElement),
@@ -1332,6 +1334,8 @@ export const mapDirectionElement = (element: Element): Direction => {
     staff: staff,
     directive: directiveAttr,
   };
+  if (offsetVal !== undefined) directionData.offset = offsetVal;
+  if (soundEl) directionData.sound = mapSoundElement(soundEl);
   return DirectionSchema.parse(directionData);
 };
 
@@ -1906,7 +1910,7 @@ export const mapPrintElement = (element: Element): Print => {
 };
 
 // Function to map a <sound> element
-export const mapSoundElement = (element: Element): Sound => {
+export function mapSoundElement(element: Element): Sound {
   const soundData: Partial<Sound> = { _type: "sound" };
   const tempoAttr = getAttribute(element, "tempo");
   const dynamicsAttr = getAttribute(element, "dynamics");
@@ -1998,7 +2002,7 @@ export const mapSoundElement = (element: Element): Sound => {
   if (idAttr) soundData.id = idAttr;
 
   return SoundSchema.parse(soundData);
-};
+}
 
 const mapFigureElement = (element: Element): Figure => {
   const data: Partial<Figure> = {

--- a/src/schemas/direction.ts
+++ b/src/schemas/direction.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { TextFormattingSchema } from "./credit"; // Assuming TextFormattingSchema includes font attributes
 import { YesNoEnum } from "./common";
+import { SoundSchema } from "./sound";
 
 // Placeholder for MetronomeBeatUnitDotSchema if needed later
 // export const MetronomeBeatUnitDotSchema = z.object({});
@@ -118,5 +119,9 @@ export const DirectionSchema = z.object({
    */
   staff: z.number().int().optional(),
   directive: YesNoEnum.optional(),
+  /** Offset in divisions from the start of the current measure or note */
+  offset: z.number().optional(),
+  /** Playback information attached to the direction */
+  sound: SoundSchema.optional(),
 });
 export type Direction = z.infer<typeof DirectionSchema>;

--- a/tests/direction.test.ts
+++ b/tests/direction.test.ts
@@ -86,4 +86,18 @@ describe("Direction parsing", () => {
     const direction = mapDirectionElement(el);
     expect(direction.directive).toBe("yes");
   });
+
+  it("extracts tempo from sound child", () => {
+    const xml = `<direction><direction-type><words>Tempo</words></direction-type><sound tempo="144"/></direction>`;
+    const el = createElement(xml);
+    const direction = mapDirectionElement(el);
+    expect(direction.sound?.tempo).toBe(144);
+  });
+
+  it("parses offset value", () => {
+    const xml = `<direction><direction-type><words>Offset</words></direction-type><offset>2.5</offset></direction>`;
+    const el = createElement(xml);
+    const direction = mapDirectionElement(el);
+    expect(direction.offset).toBe(2.5);
+  });
 });


### PR DESCRIPTION
## Summary
- extend `DirectionSchema` with optional `offset` and `sound`
- parse `<offset>` and `<sound>` in `mapDirectionElement`
- export `mapSoundElement` as a function to allow hoisting
- test tempo extraction from `<direction>` sound and offset handling

## Testing
- `npm test`