### PR TITLE
Handle missing unzip gracefully

### DIFF
--- a/src/utils/readMusicXmlFile.ts
+++ b/src/utils/readMusicXmlFile.ts
@@ -16,12 +16,21 @@ export async function readMusicXmlFile(filePath: string): Promise<string> {
   let data: Buffer;
 
   if (filePath.toLowerCase().endsWith(".mxl")) {
-    const { stdout } = await execFileAsync(
-      "unzip",
-      ["-p", filePath, "*.musicxml"],
-      { maxBuffer: 10 * 1024 * 1024, encoding: "buffer" },
-    );
-    data = stdout as Buffer;
+    try {
+      const { stdout } = await execFileAsync(
+        "unzip",
+        ["-p", filePath, "*.musicxml"],
+        { maxBuffer: 10 * 1024 * 1024, encoding: "buffer" },
+      );
+      data = stdout as Buffer;
+    } catch (err) {
+      const message =
+        (err as NodeJS.ErrnoException)?.code === "ENOENT"
+          ?
+              "The 'unzip' command is required to read MXL files. Please install it or provide a compatible environment."
+          : `Failed to extract ${filePath}: ${(err as Error).message}`;
+      throw new Error(message);
+    }
   } else {
     data = await fs.readFile(filePath);
   }

--- a/tests/readMusicXmlFile.test.ts
+++ b/tests/readMusicXmlFile.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("child_process", () => {
+  const execFile = (
+    _cmd: string,
+    _args: string[],
+    _opts: any,
+    cb: (err: NodeJS.ErrnoException | null, stdout?: string | Buffer) => void,
+  ) => {
+    const err = new Error("spawn unzip ENOENT") as NodeJS.ErrnoException;
+    err.code = "ENOENT";
+    cb(err);
+  };
+  return { execFile, default: { execFile } };
+});
+
+import { readMusicXmlFile } from "../src/utils/readMusicXmlFile";
+
+describe("readMusicXmlFile unzip fallback", () => {
+  it("throws a helpful error when unzip is missing", async () => {
+    await expect(readMusicXmlFile("dummy.mxl")).rejects.toThrow(/unzip/);
+  });
+});


### PR DESCRIPTION
## Summary
- throw a friendly error when `unzip` is missing
- add a unit test that simulates an absent `unzip`

## Testing
- `npm test`