### PR TITLE
Add support for additional direction-type elements

### DIFF
--- a/src/parser/mappers/noteMeasureMappers.ts
+++ b/src/parser/mappers/noteMeasureMappers.ts
@@ -124,6 +124,11 @@ import type {
   Feature,
   Link,
   Bookmark,
+  Rehearsal,
+  OctaveShift,
+  Dashes,
+  Bracket,
+  Image,
 } from "../../types";
 import {
   PitchSchema,
@@ -228,6 +233,11 @@ import {
   WedgeSchema,
   SegnoSchema,
   CodaSchema,
+  RehearsalSchema,
+  OctaveShiftSchema,
+  DashesSchema,
+  BracketSchema,
+  ImageSchema,
   GroupSymbolValueEnum,
   RootSchema,
   KindSchema,
@@ -1116,6 +1126,235 @@ const mapWordsElement = (element: Element): Words => {
   }
 };
 
+const mapRehearsalElement = (element: Element): Rehearsal => {
+  const text = element.textContent?.trim() ?? "";
+  const formatting: Partial<TextFormatting> = {};
+  const fontFamily = getAttribute(element, "font-family");
+  const fontStyleAttr = getAttribute(element, "font-style");
+  const fontSize = getAttribute(element, "font-size");
+  const fontWeightAttr = getAttribute(element, "font-weight");
+  const justifyAttr = getAttribute(element, "justify");
+  const defaultX = parseOptionalNumberAttribute(element, "default-x");
+  const defaultY = parseOptionalNumberAttribute(element, "default-y");
+  const valignAttr = getAttribute(element, "valign");
+  const colorAttr = getAttribute(element, "color");
+
+  if (fontFamily) formatting.fontFamily = fontFamily;
+  if (fontSize) formatting.fontSize = fontSize;
+  if (defaultX !== undefined) formatting.defaultX = defaultX;
+  if (defaultY !== undefined) formatting.defaultY = defaultY;
+  if (colorAttr) formatting.color = colorAttr;
+  if (fontStyleAttr === "normal" || fontStyleAttr === "italic") {
+    formatting.fontStyle = fontStyleAttr;
+  }
+  if (fontWeightAttr === "normal" || fontWeightAttr === "bold") {
+    formatting.fontWeight = fontWeightAttr;
+  }
+  if (justifyAttr === "left" || justifyAttr === "center" || justifyAttr === "right") {
+    formatting.justify = justifyAttr;
+  }
+  if (
+    valignAttr === "top" ||
+    valignAttr === "middle" ||
+    valignAttr === "bottom" ||
+    valignAttr === "baseline"
+  ) {
+    formatting.valign = valignAttr;
+  }
+
+  const data: Partial<Rehearsal> = { text };
+  if (Object.keys(formatting).length > 0) data.formatting = formatting as TextFormatting;
+  return RehearsalSchema.parse(data);
+};
+
+const mapOctaveShiftElement = (element: Element): OctaveShift => {
+  const data: Partial<OctaveShift> = {
+    type: getAttribute(element, "type") as
+      | "up"
+      | "down"
+      | "stop"
+      | "continue"
+      | undefined,
+  };
+  const numAttr = getAttribute(element, "number");
+  if (numAttr) {
+    const n = parseOptionalInt(numAttr);
+    if (n !== undefined) data.number = n;
+  }
+  const sizeAttr = getAttribute(element, "size");
+  if (sizeAttr) {
+    const s = parseOptionalInt(sizeAttr);
+    if (s !== undefined) data.size = s;
+  }
+  const dashLenAttr = getAttribute(element, "dash-length");
+  if (dashLenAttr) {
+    const dl = parseOptionalFloat(dashLenAttr);
+    if (dl !== undefined) data.dashLength = dl;
+  }
+  const spaceLenAttr = getAttribute(element, "space-length");
+  if (spaceLenAttr) {
+    const sl = parseOptionalFloat(spaceLenAttr);
+    if (sl !== undefined) data.spaceLength = sl;
+  }
+  const defaultXAttr = getAttribute(element, "default-x");
+  if (defaultXAttr) {
+    const dx = parseOptionalFloat(defaultXAttr);
+    if (dx !== undefined) data.defaultX = dx;
+  }
+  const defaultYAttr = getAttribute(element, "default-y");
+  if (defaultYAttr) {
+    const dy = parseOptionalFloat(defaultYAttr);
+    if (dy !== undefined) data.defaultY = dy;
+  }
+  const relativeXAttr = getAttribute(element, "relative-x");
+  if (relativeXAttr) {
+    const rx = parseOptionalFloat(relativeXAttr);
+    if (rx !== undefined) data.relativeX = rx;
+  }
+  const relativeYAttr = getAttribute(element, "relative-y");
+  if (relativeYAttr) {
+    const ry = parseOptionalFloat(relativeYAttr);
+    if (ry !== undefined) data.relativeY = ry;
+  }
+  const colorAttr = getAttribute(element, "color");
+  if (colorAttr) data.color = colorAttr;
+  const idAttr = getAttribute(element, "id");
+  if (idAttr) data.id = idAttr;
+  return OctaveShiftSchema.parse(data);
+};
+
+const mapDashesElement = (element: Element): Dashes => {
+  const data: Partial<Dashes> = {
+    type: getAttribute(element, "type") as
+      | "start"
+      | "stop"
+      | "continue"
+      | undefined,
+  };
+  const numAttr = getAttribute(element, "number");
+  if (numAttr) {
+    const n = parseOptionalInt(numAttr);
+    if (n !== undefined) data.number = n;
+  }
+  const dashLenAttr = getAttribute(element, "dash-length");
+  if (dashLenAttr) {
+    const dl = parseOptionalFloat(dashLenAttr);
+    if (dl !== undefined) data.dashLength = dl;
+  }
+  const spaceLenAttr = getAttribute(element, "space-length");
+  if (spaceLenAttr) {
+    const sl = parseOptionalFloat(spaceLenAttr);
+    if (sl !== undefined) data.spaceLength = sl;
+  }
+  const defaultXAttr = getAttribute(element, "default-x");
+  if (defaultXAttr) {
+    const dx = parseOptionalFloat(defaultXAttr);
+    if (dx !== undefined) data.defaultX = dx;
+  }
+  const defaultYAttr = getAttribute(element, "default-y");
+  if (defaultYAttr) {
+    const dy = parseOptionalFloat(defaultYAttr);
+    if (dy !== undefined) data.defaultY = dy;
+  }
+  const relativeXAttr = getAttribute(element, "relative-x");
+  if (relativeXAttr) {
+    const rx = parseOptionalFloat(relativeXAttr);
+    if (rx !== undefined) data.relativeX = rx;
+  }
+  const relativeYAttr = getAttribute(element, "relative-y");
+  if (relativeYAttr) {
+    const ry = parseOptionalFloat(relativeYAttr);
+    if (ry !== undefined) data.relativeY = ry;
+  }
+  const colorAttr = getAttribute(element, "color");
+  if (colorAttr) data.color = colorAttr;
+  const idAttr = getAttribute(element, "id");
+  if (idAttr) data.id = idAttr;
+  return DashesSchema.parse(data);
+};
+
+const mapBracketElement = (element: Element): Bracket => {
+  const data: Partial<Bracket> = {
+    type: getAttribute(element, "type") as
+      | "start"
+      | "stop"
+      | "continue"
+      | undefined,
+  };
+  const numAttr = getAttribute(element, "number");
+  if (numAttr) {
+    const n = parseOptionalInt(numAttr);
+    if (n !== undefined) data.number = n;
+  }
+  const lineEndAttr = getAttribute(element, "line-end");
+  if (lineEndAttr)
+    data.lineEnd = lineEndAttr as "up" | "down" | "both" | "arrow" | "none";
+  const endLenAttr = getAttribute(element, "end-length");
+  if (endLenAttr) {
+    const el = parseOptionalFloat(endLenAttr);
+    if (el !== undefined) data.endLength = el;
+  }
+  const lineTypeAttr = getAttribute(element, "line-type");
+  if (lineTypeAttr) data.lineType = lineTypeAttr;
+  const dashLenAttr = getAttribute(element, "dash-length");
+  if (dashLenAttr) {
+    const dl = parseOptionalFloat(dashLenAttr);
+    if (dl !== undefined) data.dashLength = dl;
+  }
+  const spaceLenAttr = getAttribute(element, "space-length");
+  if (spaceLenAttr) {
+    const sl = parseOptionalFloat(spaceLenAttr);
+    if (sl !== undefined) data.spaceLength = sl;
+  }
+  const defaultXAttr = getAttribute(element, "default-x");
+  if (defaultXAttr) {
+    const dx = parseOptionalFloat(defaultXAttr);
+    if (dx !== undefined) data.defaultX = dx;
+  }
+  const defaultYAttr = getAttribute(element, "default-y");
+  if (defaultYAttr) {
+    const dy = parseOptionalFloat(defaultYAttr);
+    if (dy !== undefined) data.defaultY = dy;
+  }
+  const relativeXAttr = getAttribute(element, "relative-x");
+  if (relativeXAttr) {
+    const rx = parseOptionalFloat(relativeXAttr);
+    if (rx !== undefined) data.relativeX = rx;
+  }
+  const relativeYAttr = getAttribute(element, "relative-y");
+  if (relativeYAttr) {
+    const ry = parseOptionalFloat(relativeYAttr);
+    if (ry !== undefined) data.relativeY = ry;
+  }
+  const colorAttr = getAttribute(element, "color");
+  if (colorAttr) data.color = colorAttr;
+  const idAttr = getAttribute(element, "id");
+  if (idAttr) data.id = idAttr;
+  return BracketSchema.parse(data);
+};
+
+const mapImageElement = (element: Element): Image | undefined => {
+  const source = getAttribute(element, "source");
+  const typeAttr = getAttribute(element, "type");
+  if (!source || !typeAttr) return undefined;
+  const data: Partial<Image> = { source, type: typeAttr };
+  const h = parseOptionalFloat(getAttribute(element, "height"));
+  if (h !== undefined) data.height = h;
+  const w = parseOptionalFloat(getAttribute(element, "width"));
+  if (w !== undefined) data.width = w;
+  const dx = parseOptionalFloat(getAttribute(element, "default-x"));
+  if (dx !== undefined) data.defaultX = dx;
+  const dy = parseOptionalFloat(getAttribute(element, "default-y"));
+  if (dy !== undefined) data.defaultY = dy;
+  const ha = getAttribute(element, "halign");
+  if (ha && ["left", "center", "right"].includes(ha))
+    data.halign = ha as "left" | "center" | "right";
+  const va = getAttribute(element, "valign");
+  if (va && ["top", "middle", "bottom"].includes(va))
+    data.valign = va as "top" | "middle" | "bottom";
+  return ImageSchema.parse(data);
+};
+
 // Helper function to map a <beat-unit> element (within <metronome>)
 const mapMetronomeBeatUnitElement = (element: Element): MetronomeBeatUnit => {
   const beatUnitDotElements = Array.from(
@@ -1208,6 +1447,11 @@ const mapDirectionTypeElement = (element: Element): DirectionType => {
   const wedgeElement = element.querySelector("wedge");
   const segnoElement = element.querySelector("segno");
   const codaElement = element.querySelector("coda");
+  const rehearsalElement = element.querySelector("rehearsal");
+  const octaveShiftElement = element.querySelector("octave-shift");
+  const dashesElement = element.querySelector("dashes");
+  const bracketElement = element.querySelector("bracket");
+  const imageElement = element.querySelector("image");
   const directionTypeData: Partial<DirectionType> = {};
   if (wordsElement) {
     directionTypeData.words = mapWordsElement(wordsElement);
@@ -1300,6 +1544,22 @@ const mapDirectionTypeElement = (element: Element): DirectionType => {
     const idAttr = getAttribute(wedgeElement, "id");
     if (idAttr) wedgeData.id = idAttr;
     directionTypeData.wedge = WedgeSchema.parse(wedgeData);
+  }
+  if (rehearsalElement) {
+    directionTypeData.rehearsal = mapRehearsalElement(rehearsalElement);
+  }
+  if (octaveShiftElement) {
+    directionTypeData.octaveShift = mapOctaveShiftElement(octaveShiftElement);
+  }
+  if (dashesElement) {
+    directionTypeData.dashes = mapDashesElement(dashesElement);
+  }
+  if (bracketElement) {
+    directionTypeData.bracket = mapBracketElement(bracketElement);
+  }
+  if (imageElement) {
+    const img = mapImageElement(imageElement);
+    if (img) directionTypeData.image = img;
   }
   if (segnoElement) {
     directionTypeData.segno = SegnoSchema.parse({});

--- a/src/schemas/direction.ts
+++ b/src/schemas/direction.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { TextFormattingSchema } from "./credit"; // Assuming TextFormattingSchema includes font attributes
+import { TextFormattingSchema, CreditImageSchema } from "./credit"; // Assuming TextFormattingSchema includes font attributes
 import { YesNoEnum } from "./common";
 
 // Placeholder for MetronomeBeatUnitDotSchema if needed later
@@ -13,6 +13,13 @@ export const WordsSchema = z.object({
   formatting: TextFormattingSchema.optional(), // Includes font and color attributes
 });
 export type Words = z.infer<typeof WordsSchema>;
+
+/** Representation of a <rehearsal> element. */
+export const RehearsalSchema = z.object({
+  text: z.string(),
+  formatting: TextFormattingSchema.optional(),
+});
+export type Rehearsal = z.infer<typeof RehearsalSchema>;
 
 export const MetronomeBeatUnitSchema = z.object({
   "beat-unit": z.string(), // e.g., "quarter", "eighth"
@@ -83,6 +90,55 @@ export type Segno = z.infer<typeof SegnoSchema>;
 export const CodaSchema = z.object({});
 export type Coda = z.infer<typeof CodaSchema>;
 
+export const OctaveShiftSchema = z.object({
+  type: z.enum(["up", "down", "stop", "continue"]).optional(),
+  number: z.number().int().optional(),
+  size: z.number().int().optional(),
+  dashLength: z.number().optional(),
+  spaceLength: z.number().optional(),
+  defaultX: z.number().optional(),
+  defaultY: z.number().optional(),
+  relativeX: z.number().optional(),
+  relativeY: z.number().optional(),
+  color: z.string().optional(),
+  id: z.string().optional(),
+});
+export type OctaveShift = z.infer<typeof OctaveShiftSchema>;
+
+export const DashesSchema = z.object({
+  type: z.enum(["start", "stop", "continue"]).optional(),
+  number: z.number().int().optional(),
+  dashLength: z.number().optional(),
+  spaceLength: z.number().optional(),
+  defaultX: z.number().optional(),
+  defaultY: z.number().optional(),
+  relativeX: z.number().optional(),
+  relativeY: z.number().optional(),
+  color: z.string().optional(),
+  id: z.string().optional(),
+});
+export type Dashes = z.infer<typeof DashesSchema>;
+
+export const BracketSchema = z.object({
+  type: z.enum(["start", "stop", "continue"]).optional(),
+  number: z.number().int().optional(),
+  lineEnd: z.enum(["up", "down", "both", "arrow", "none"]).optional(),
+  endLength: z.number().optional(),
+  lineType: z.string().optional(),
+  dashLength: z.number().optional(),
+  spaceLength: z.number().optional(),
+  defaultX: z.number().optional(),
+  defaultY: z.number().optional(),
+  relativeX: z.number().optional(),
+  relativeY: z.number().optional(),
+  color: z.string().optional(),
+  id: z.string().optional(),
+});
+export type Bracket = z.infer<typeof BracketSchema>;
+
+export const ImageSchema = CreditImageSchema;
+export type Image = z.infer<typeof ImageSchema>;
+
 /**
  * Represents the <direction-type> element, which contains the actual content of a direction.
  */
@@ -94,6 +150,11 @@ export const DirectionTypeSchema = z.object({
   wedge: WedgeSchema.optional(),
   segno: SegnoSchema.optional(),
   coda: CodaSchema.optional(),
+  rehearsal: RehearsalSchema.optional(),
+  octaveShift: OctaveShiftSchema.optional(),
+  dashes: DashesSchema.optional(),
+  bracket: BracketSchema.optional(),
+  image: ImageSchema.optional(),
 });
 export type DirectionType = z.infer<typeof DirectionTypeSchema>;
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,6 +30,11 @@ export type {
   Wedge,
   Segno,
   Coda,
+  Rehearsal,
+  OctaveShift,
+  Dashes,
+  Bracket,
+  Image,
 } from "../schemas/direction";
 
 export type {

--- a/tests/direction.test.ts
+++ b/tests/direction.test.ts
@@ -86,4 +86,58 @@ describe("Direction parsing", () => {
     const direction = mapDirectionElement(el);
     expect(direction.directive).toBe("yes");
   });
+
+  it("parses rehearsal element", () => {
+    const xml = `<direction><direction-type><rehearsal font-weight="bold">A</rehearsal></direction-type></direction>`;
+    const el = createElement(xml);
+    const direction = mapDirectionElement(el);
+    const reh = direction.direction_type[0].rehearsal!;
+    expect(reh.text).toBe("A");
+    expect(reh.formatting?.fontWeight).toBe("bold");
+  });
+
+  it("parses octave-shift element", () => {
+    const xml = `<direction><direction-type><octave-shift type="down" size="8" number="1" dash-length="7.5" space-length="7.5"/></direction-type></direction>`;
+    const el = createElement(xml);
+    const direction = mapDirectionElement(el);
+    const os = direction.direction_type[0].octaveShift!;
+    expect(os.type).toBe("down");
+    expect(os.size).toBe(8);
+    expect(os.number).toBe(1);
+    expect(os.dashLength).toBe(7.5);
+    expect(os.spaceLength).toBe(7.5);
+  });
+
+  it("parses dashes element", () => {
+    const xml = `<direction><direction-type><dashes type="start" number="2" dash-length="3" space-length="1"/></direction-type></direction>`;
+    const el = createElement(xml);
+    const direction = mapDirectionElement(el);
+    const d = direction.direction_type[0].dashes!;
+    expect(d.type).toBe("start");
+    expect(d.number).toBe(2);
+    expect(d.dashLength).toBe(3);
+    expect(d.spaceLength).toBe(1);
+  });
+
+  it("parses bracket element", () => {
+    const xml = `<direction><direction-type><bracket type="start" line-end="down" number="1" line-type="solid"/></direction-type></direction>`;
+    const el = createElement(xml);
+    const direction = mapDirectionElement(el);
+    const b = direction.direction_type[0].bracket!;
+    expect(b.type).toBe("start");
+    expect(b.lineEnd).toBe("down");
+    expect(b.number).toBe(1);
+    expect(b.lineType).toBe("solid");
+  });
+
+  it("parses image element", () => {
+    const xml = `<direction><direction-type><image source="img.png" type="image/png" width="20" height="10"/></direction-type></direction>`;
+    const el = createElement(xml);
+    const direction = mapDirectionElement(el);
+    const img = direction.direction_type[0].image!;
+    expect(img.source).toBe("img.png");
+    expect(img.type).toBe("image/png");
+    expect(img.width).toBe(20);
+    expect(img.height).toBe(10);
+  });
 });


### PR DESCRIPTION
## Summary
- extend `DirectionTypeSchema` with rehearsal, octave-shift, dashes, bracket and image
- implement parsers for these new direction-type children
- export new types
- test parsing of all new elements

## Testing
- `npm test`