### PR TITLE
Add lyric formatting parsing

### DIFF
--- a/src/parser/mappers/noteMeasureMappers.ts
+++ b/src/parser/mappers/noteMeasureMappers.ts
@@ -94,6 +94,7 @@ import type {
   CreditImage,
   Credit,
   TextFormatting,
+  LyricFormatting,
   SymbolFormatting, // Added
   Harmony,
   Backup,
@@ -366,8 +367,15 @@ export const mapUnpitchedElement = (element: Element): Unpitched => {
 
 // Helper function to map a <lyric> element
 export const mapLyricElement = (element: Element): Lyric => {
+  const textElement = element.querySelector("text");
+  const getAttr = (name: string): string | undefined => {
+    return (
+      getAttribute(textElement ?? element, name) || getAttribute(element, name)
+    );
+  };
+
   const lyricData: Partial<Lyric> = {
-    text: getTextContent(element, "text") ?? "",
+    text: textElement?.textContent?.trim() ?? "",
     syllabic: getTextContent(element, "syllabic") as
       | "single"
       | "begin"
@@ -375,6 +383,7 @@ export const mapLyricElement = (element: Element): Lyric => {
       | "middle"
       | undefined,
   };
+
   const numberAttr = getAttribute(element, "number");
   const nameAttr = getAttribute(element, "name");
   if (numberAttr) lyricData.number = numberAttr;
@@ -397,6 +406,48 @@ export const mapLyricElement = (element: Element): Lyric => {
       text: elisionElement.textContent?.trim() || undefined,
     };
   }
+
+  const xmlLang = getAttr("xml:lang");
+  if (xmlLang) lyricData.xmlLang = xmlLang;
+
+  const formatting: Partial<Lyric["formatting"]> = {};
+  const justify = getAttr("justify");
+  if (justify === "left" || justify === "center" || justify === "right") {
+    formatting.justify = justify;
+  }
+  const fontStyle = getAttr("font-style");
+  if (fontStyle === "normal" || fontStyle === "italic") {
+    formatting.fontStyle = fontStyle;
+  }
+  const fontFamily = getAttr("font-family");
+  if (fontFamily) formatting.fontFamily = fontFamily;
+  const fontSize = getAttr("font-size");
+  if (fontSize) formatting.fontSize = fontSize;
+  const fontWeight = getAttr("font-weight");
+  if (fontWeight === "normal" || fontWeight === "bold") {
+    formatting.fontWeight = fontWeight;
+  }
+  const underlineAttr = getAttr("underline");
+  const overlineAttr = getAttr("overline");
+  const lineThroughAttr = getAttr("line-through");
+  const parseLines = (v: string | undefined): number | undefined => {
+    if (!v) return undefined;
+    const n = parseInt(v, 10);
+    return isNaN(n) ? undefined : n;
+  };
+  const underline = parseLines(underlineAttr);
+  if (underline !== undefined) formatting.underline = underline;
+  const overline = parseLines(overlineAttr);
+  if (overline !== undefined) formatting.overline = overline;
+  const lineThrough = parseLines(lineThroughAttr);
+  if (lineThrough !== undefined) formatting.lineThrough = lineThrough;
+  const color = getAttr("color");
+  if (color) formatting.color = color;
+
+  if (Object.keys(formatting).length > 0) {
+    lyricData.formatting = formatting as Lyric["formatting"];
+  }
+
   return LyricSchema.parse(lyricData);
 };
 

--- a/src/schemas/lyric.ts
+++ b/src/schemas/lyric.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { FontSchema } from "./common";
 
 export const ExtendSchema = z.object({
   type: z.enum(["start", "stop", "continue"]).optional(),
@@ -10,6 +11,15 @@ export const ElisionSchema = z.object({
 });
 export type Elision = z.infer<typeof ElisionSchema>;
 
+export const LyricFormattingSchema = FontSchema.extend({
+  justify: z.enum(["left", "center", "right"]).optional(),
+  underline: z.number().optional(),
+  overline: z.number().optional(),
+  lineThrough: z.number().optional(),
+  color: z.string().optional(),
+});
+export type LyricFormatting = z.infer<typeof LyricFormattingSchema>;
+
 export const LyricSchema = z.object({
   text: z.string(),
   syllabic: z.string().optional(), // common values: single, begin, end, middle
@@ -17,6 +27,8 @@ export const LyricSchema = z.object({
   name: z.string().optional(),
   extend: ExtendSchema.optional(),
   elision: ElisionSchema.optional(),
+  xmlLang: z.string().optional(),
+  formatting: LyricFormattingSchema.optional(),
 });
 
 export type Lyric = z.infer<typeof LyricSchema>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,7 +13,7 @@ export type { Key } from "../schemas/key";
 export type { Time } from "../schemas/time";
 export type { Clef } from "../schemas/clef";
 export type { Attributes } from "../schemas/attributes";
-export type { Lyric, Extend, Elision } from "../schemas/lyric";
+export type { Lyric, Extend, Elision, LyricFormatting } from "../schemas/lyric";
 export type { Tie } from "../schemas/tie";
 export type { Tie as Tied } from "../schemas/tie";
 export type {

--- a/tests/lyric.test.ts
+++ b/tests/lyric.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { mapLyricElement } from "../src/parser/mappers";
+import type { Lyric } from "../src/types";
+import { JSDOM } from "jsdom";
+
+function createElement(xmlString: string): Element {
+  const dom = new JSDOM(xmlString, { contentType: "application/xml" });
+  const parsererror = dom.window.document.querySelector("parsererror");
+  if (parsererror) {
+    throw new Error(
+      `Failed to parse XML string snippet: ${parsererror.textContent}`,
+    );
+  }
+  if (!dom.window.document.documentElement) {
+    throw new Error("No document element found in XML string snippet.");
+  }
+  return dom.window.document.documentElement;
+}
+
+describe("Lyric mapping", () => {
+  it("parses xml:lang and formatting attributes", () => {
+    const xml = `<lyric xml:lang="la" justify="center"><text font-style="italic" underline="2">Deus</text></lyric>`;
+    const element = createElement(xml);
+    const lyric = mapLyricElement(element) as Lyric;
+    expect(lyric.text).toBe("Deus");
+    expect(lyric.xmlLang).toBe("la");
+    expect(lyric.formatting?.justify).toBe("center");
+    expect(lyric.formatting?.fontStyle).toBe("italic");
+    expect(lyric.formatting?.underline).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- extend LyricSchema with formatting and xmlLang
- parse lyric formatting attributes in note mappers
- export new LyricFormatting type
- add unit test for lyric formatting

## Testing
- `npm run format`
- `npm test`