### PR TITLE
Handle arpeggiate notation

### DIFF
--- a/src/parser/mappers/noteMeasureMappers.ts
+++ b/src/parser/mappers/noteMeasureMappers.ts
@@ -59,6 +59,8 @@ import type {
   Glissando,
   Slide,
   Tremolo,
+  Arpeggiate,
+  NonArpeggiate,
   OtherNotation,
   Tie,
   Barline,
@@ -190,6 +192,8 @@ import {
   GlissandoSchema,
   SlideSchema,
   TremoloSchema,
+  ArpeggiateSchema,
+  NonArpeggiateSchema,
   OtherNotationSchema,
   TieSchema,
   BarlineSchema,
@@ -1055,6 +1059,29 @@ const mapOtherNotationElement = (element: Element): OtherNotation => {
   return OtherNotationSchema.parse(data);
 };
 
+const mapArpeggiateElement = (element: Element): Arpeggiate => {
+  const data: Partial<Arpeggiate> = {
+    number: parseOptionalNumberAttribute(element, "number"),
+    direction: getAttribute(element, "direction") as "up" | "down" | undefined,
+    unbroken: getAttribute(element, "unbroken") as "yes" | "no" | undefined,
+  };
+  return ArpeggiateSchema.parse(data);
+};
+
+const mapNonArpeggiateElement = (element: Element): NonArpeggiate => {
+  const typeAttr = getAttribute(element, "type") as "top" | "bottom" | undefined;
+  if (!typeAttr) {
+    throw new Error(
+      '<non-arpeggiate> element requires a "type" attribute.',
+    );
+  }
+  const data: Partial<NonArpeggiate> = {
+    type: typeAttr,
+    number: parseOptionalNumberAttribute(element, "number"),
+  };
+  return NonArpeggiateSchema.parse(data);
+};
+
 // Helper function to map a <words> element (within <direction-type>)
 const mapWordsElement = (element: Element): Words => {
   const text = element.textContent?.trim() ?? "";
@@ -1348,6 +1375,12 @@ const mapNotationsElement = (element: Element): Notations => {
   const glissandoElements = Array.from(element.querySelectorAll("glissando"));
   const slideElements = Array.from(element.querySelectorAll("slide"));
   const tremoloElements = Array.from(element.querySelectorAll("tremolo"));
+  const arpeggiateElements = Array.from(
+    element.querySelectorAll("arpeggiate"),
+  );
+  const nonArpeggiateElements = Array.from(
+    element.querySelectorAll("non-arpeggiate"),
+  );
   const otherNotationElements = Array.from(
     element.querySelectorAll("other-notation"),
   );
@@ -1382,6 +1415,14 @@ const mapNotationsElement = (element: Element): Notations => {
   }
   if (tremoloElements.length > 0) {
     notationsData.tremolos = tremoloElements.map(mapTremoloElement);
+  }
+  if (arpeggiateElements.length > 0) {
+    notationsData.arpeggiates = arpeggiateElements.map(mapArpeggiateElement);
+  }
+  if (nonArpeggiateElements.length > 0) {
+    notationsData.nonArpeggiates = nonArpeggiateElements.map(
+      mapNonArpeggiateElement,
+    );
   }
   if (otherNotationElements.length > 0) {
     notationsData.otherNotations = otherNotationElements.map(

--- a/src/schemas/notations.ts
+++ b/src/schemas/notations.ts
@@ -4,6 +4,13 @@ import { YesNoEnum } from "./common";
 import { WavyLineSchema } from "./wavyLine";
 import { AccidentalSchema } from "./accidental";
 
+// Additional enums used by arpeggiate and non-arpeggiate elements
+export const UpDownEnum = z.enum(["up", "down"]);
+export type UpDown = z.infer<typeof UpDownEnum>;
+
+export const TopBottomEnum = z.enum(["top", "bottom"]);
+export type TopBottom = z.infer<typeof TopBottomEnum>;
+
 /**
  * The slur element is used to represent slurs. Slurs can be nested.
  */
@@ -242,6 +249,25 @@ export const OtherNotationSchema = z.object({
 export type OtherNotation = z.infer<typeof OtherNotationSchema>;
 
 /**
+ * Indicates that this note is part of an arpeggiated chord.
+ */
+export const ArpeggiateSchema = z.object({
+  number: z.number().int().optional(),
+  direction: UpDownEnum.optional(),
+  unbroken: YesNoEnum.optional(),
+});
+export type Arpeggiate = z.infer<typeof ArpeggiateSchema>;
+
+/**
+ * Indicates the top or bottom note of a non-arpeggiate bracket.
+ */
+export const NonArpeggiateSchema = z.object({
+  type: TopBottomEnum,
+  number: z.number().int().optional(),
+});
+export type NonArpeggiate = z.infer<typeof NonArpeggiateSchema>;
+
+/**
  * The articulations element groups multiple articulation marks.
  */
 export const ArticulationsSchema = z.object({
@@ -269,6 +295,8 @@ export const NotationsSchema = z.object({
   glissandos: z.array(GlissandoSchema).optional(),
   slides: z.array(SlideSchema).optional(),
   tremolos: z.array(TremoloSchema).optional(),
+  arpeggiates: z.array(ArpeggiateSchema).optional(),
+  nonArpeggiates: z.array(NonArpeggiateSchema).optional(),
   otherNotations: z.array(OtherNotationSchema).optional(),
 });
 export type Notations = z.infer<typeof NotationsSchema>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -69,6 +69,8 @@ export type {
   Mordent,
   Schleifer,
   OtherOrnament,
+  Arpeggiate,
+  NonArpeggiate,
   Technical,
 } from "../schemas/notations";
 export type { Barline, BarStyle, Repeat, Ending } from "../schemas/barline";
@@ -155,6 +157,8 @@ export type {
   Slide,
   Tremolo,
   OtherNotation,
+  Arpeggiate,
+  NonArpeggiate,
 } from "../schemas/notations";
 export type { MidiDevice } from "../schemas/midiDevice";
 export type { TimeModification } from "../schemas/timeModification";

--- a/tests/notations.test.ts
+++ b/tests/notations.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { mapNoteElement } from "../src/parser/mappers";
+import type { Arpeggiate, NonArpeggiate } from "../src/types";
+import { JSDOM } from "jsdom";
+
+function createElement(xmlString: string): Element {
+  const dom = new JSDOM(xmlString, { contentType: "application/xml" });
+  const parsererror = dom.window.document.querySelector("parsererror");
+  if (parsererror) {
+    throw new Error(`Failed to parse XML string snippet: ${parsererror.textContent}`);
+  }
+  if (!dom.window.document.documentElement) {
+    throw new Error("No document element found in XML string snippet.");
+  }
+  return dom.window.document.documentElement;
+}
+
+describe("Notations arpeggiate and non-arpeggiate", () => {
+  it("parses an <arpeggiate> element", () => {
+    const xml = '<note><pitch><step>C</step><octave>4</octave></pitch><duration>1</duration><notations><arpeggiate number="2" direction="down" unbroken="yes"/></notations></note>';
+    const el = createElement(xml);
+    const note = mapNoteElement(el);
+    expect(note.notations?.arpeggiates).toHaveLength(1);
+    const arp = note.notations?.arpeggiates?.[0] as Arpeggiate;
+    expect(arp.number).toBe(2);
+    expect(arp.direction).toBe("down");
+    expect(arp.unbroken).toBe("yes");
+  });
+
+  it("parses a <non-arpeggiate> element", () => {
+    const xml = '<note><pitch><step>C</step><octave>4</octave></pitch><duration>1</duration><notations><non-arpeggiate type="top" number="1"/></notations></note>';
+    const el = createElement(xml);
+    const note = mapNoteElement(el);
+    expect(note.notations?.nonArpeggiates).toHaveLength(1);
+    const na = note.notations?.nonArpeggiates?.[0] as NonArpeggiate;
+    expect(na.type).toBe("top");
+    expect(na.number).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- support `<arpeggiate>` and `<non-arpeggiate>` in notation schemas
- parse new notation elements in note mappers
- export new notation types
- add unit tests for arpeggiate and non-arpeggiate

## Testing
- `npm test`