### PR TITLE
Refactor ScoreTimewise schema

### DIFF
--- a/src/schemas/scoreTimewise.ts
+++ b/src/schemas/scoreTimewise.ts
@@ -6,27 +6,29 @@ import { IdentificationSchema } from "./identification";
 import { DefaultsSchema } from "./defaults";
 import { CreditSchema } from "./credit";
 
+/** Helper schema for score-level metadata fields */
+export const ScoreTimewiseMetadataSchema = z.object({
+  version: z.string().optional().default("1.0"),
+  work: WorkSchema.optional(),
+  movementTitle: z.string().optional(),
+  identification: IdentificationSchema.optional(),
+  defaults: DefaultsSchema.optional(),
+  credit: z.array(CreditSchema).optional(),
+});
+
+/** Helper schema for required measure data */
+export const ScoreTimewiseMeasureGroupSchema = z.object({
+  partList: PartListSchema,
+  measures: z.array(TimewiseMeasureSchema).min(1),
+});
+
 /**
  * Represents the <score-timewise> element, where measures contain parts.
+ * Composed from smaller schemas to avoid exceeding TypeScript's type
+ * serialization limits.
  */
-// FIXME: TS7056: The inferred type of this node exceeds the maximum length the compiler will serialize.
-// This is a temporary workaround to suppress the TypeScript error.
-// This complex type inference issue should be addressed by refactoring the underlying schemas
-// (e.g., TimewiseMeasureSchema and its components) to reduce complexity.
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore TS7056
-export const ScoreTimewiseSchema = z
-  .object({
-    version: z.string().optional().default("1.0"),
-    work: WorkSchema.optional(),
-    movementTitle: z.string().optional(),
-    identification: IdentificationSchema.optional(),
-    defaults: DefaultsSchema.optional(),
-    credit: z.array(CreditSchema).optional(),
-    partList: PartListSchema,
-    measures: z.array(TimewiseMeasureSchema).min(1),
-  })
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  .passthrough() as any;
+export const ScoreTimewiseSchema = ScoreTimewiseMetadataSchema.merge(
+  ScoreTimewiseMeasureGroupSchema,
+).passthrough();
 
 export type ScoreTimewise = z.infer<typeof ScoreTimewiseSchema>;


### PR DESCRIPTION
## Summary
- break down `ScoreTimewiseSchema` into smaller helper schemas
- compose the pieces so the schema builds cleanly without `ts-ignore`

## Testing
- `npm run type-check`
- `npm run lint`
- `npm test`
