### PR TITLE
Replace unzip command usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This project is currently in **Phase 1: Core Parsing Functionality**.
 *   Maps the parsed DOM structure to a typed JavaScript object (`ScorePartwise`) according to the defined Zod schemas.
 *   Validates the mapped object against the Zod schemas at each step of the mapping process.
 *   Basic unit tests for the core parsing and mapping logic.
+*   Reads `.mxl` archives directly using Node.js—no external `unzip` command is required.
 
 **Design Choices:**
 *   **DOM-based Parsing:** Utilizes `DOMParser` in browsers and loads `jsdom` on demand in Node.js to build a Document Object Model from the MusicXML string. This approach was chosen for its suitability for both transformation and potential future editing capabilities, offering easier random access and manipulation of the XML structure compared to SAX-based parsing.

--- a/tests/readMusicXmlFile.test.ts
+++ b/tests/readMusicXmlFile.test.ts
@@ -1,23 +1,17 @@
-import { describe, it, expect, vi } from "vitest";
-
-vi.mock("child_process", () => {
-  const execFile = (
-    _cmd: string,
-    _args: string[],
-    _opts: any,
-    cb: (err: NodeJS.ErrnoException | null, stdout?: string | Buffer) => void,
-  ) => {
-    const err = new Error("spawn unzip ENOENT") as NodeJS.ErrnoException;
-    err.code = "ENOENT";
-    cb(err);
-  };
-  return { execFile, default: { execFile } };
-});
-
+import { describe, it, expect } from "vitest";
+import * as path from "path";
 import { readMusicXmlFile } from "../src/utils/readMusicXmlFile";
 
-describe("readMusicXmlFile unzip fallback", () => {
-  it("throws a helpful error when unzip is missing", async () => {
-    await expect(readMusicXmlFile("dummy.mxl")).rejects.toThrow(/unzip/);
+const samplesDir = path.resolve(__dirname, "../reference/xmlsamples");
+
+describe("readMusicXmlFile", () => {
+  it("extracts MusicXML from MXL archives", async () => {
+    const fromArchive = await readMusicXmlFile(
+      path.join(samplesDir, "ActorPreludeSample.mxl"),
+    );
+    const direct = await readMusicXmlFile(
+      path.join(samplesDir, "ActorPreludeSample.musicxml"),
+    );
+    expect(fromArchive).toBe(direct);
   });
 });


### PR DESCRIPTION
## Summary
- drop system unzip requirement
- implement pure Node.js archive extraction
- adjust tests for new extraction logic
- mention removal of external dependency in README

## Testing
- `npm run build`
- `npm test`