### PR TITLE
Update linting to include tests

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -30,6 +30,14 @@ export default [
   },
   ...tseslint.configs.recommended, // Apply recommended TypeScript rules
   {
+    files: ["tests/**/*.ts"],
+    rules: {
+      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-non-null-asserted-optional-chain": "off",
+      "@typescript-eslint/ban-ts-comment": "off",
+    },
+  },
+  {
     // Prettierとの連携設定
     // Prettier関連の設定は一番最後に配置することが推奨されます
     // (他のルール設定を上書きできるようにするため)

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "lint": "eslint src/**/*.ts",
-    "lint:fix": "eslint src/**/*.ts --fix",
+    "lint": "eslint \"src/**/*.ts\" \"tests/**/*.ts\"",
+    "lint:fix": "eslint \"src/**/*.ts\" \"tests/**/*.ts\" --fix",
     "format": "prettier --write \"src/**/*.ts\" \"tests/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.ts\" \"tests/**/*.ts\"",
     "test": "vitest run",

--- a/src/parser/mappers/noteMeasureMappers.ts
+++ b/src/parser/mappers/noteMeasureMappers.ts
@@ -875,7 +875,7 @@ const mapOtherOrnamentElement = (el: Element): OtherOrnament => {
 
 const mapAccidentalMarkElement = (el: Element): Accidental => {
   const value = el.textContent?.trim() || "";
-  return AccidentalSchema.parse({ value: value as any });
+  return AccidentalSchema.parse({ value: value as AccidentalValue });
 };
 
 const mapOrnamentsElement = (element: Element): Ornaments => {


### PR DESCRIPTION
## Summary
- include `tests/**/*.ts` in lint and lint:fix scripts
- relax several ESLint rules for the test files
- fix explicit-any in `noteMeasureMappers`

## Testing
- `npm run lint`
- `npm test`
- `npm run lint:fix`
