### PR TITLE
Implement MusicXML conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,17 @@ run().catch((e) => console.error(e));
 Once you have a `ScorePartwise` object you can convert it into other formats:
 
 ```typescript
-import { toMusicJson, toYaml, toToneJsSequence, toMidi } from 'your-musicxml-parser-package-name';
+import {
+  toMusicJson,
+  toYaml,
+  toToneJsSequence,
+  toMidi,
+  toMusicXML,
+} from 'your-musicxml-parser-package-name';
 
 const json = toMusicJson(score);
 const yamlString = toYaml(score);
+const xmlString = toMusicXML(score);
 const toneSeq = toToneJsSequence(score);
 const midi = toMidi(score);
 ```
@@ -152,10 +159,7 @@ const midi = toMidi(score);
     *   Implement mappers for other top-level metadata elements (`<work>`, `<identification>`, `<defaults>`, `<credit>`).
     *   Support for `<score-timewise>` if necessary.
 *   **Phase 3: Conversion Utilities:**
-    *   Implement `toMusicJson()`: Convert the `ScorePartwise` object to a JSON string.
-    *   Implement `toYaml()`: Convert to YAML string (using `js-yaml` or similar).
-    *   Investigate and implement `toToneJsSequence()`: Convert to a format suitable for Tone.js.
-    *   Investigate and implement `toMidi()`: Convert to MIDI format (potentially using libraries like `tonejs/Midi` or `midiconvert`).
+    *   Add `toMusicXML()` for serializing a parsed score back into MusicXML.
 *   **Phase 4: Enhancements & Optimizations:**
     *   Performance profiling and optimization for large MusicXML files.
     *   Error handling improvements and configurable logging.

--- a/src/converters/index.ts
+++ b/src/converters/index.ts
@@ -2,3 +2,4 @@ export * from "./toMusicJson";
 export * from "./toYaml";
 export * from "./toToneJsSequence";
 export * from "./toMidi";
+export * from "./toMusicXML";

--- a/src/converters/toMusicXML.ts
+++ b/src/converters/toMusicXML.ts
@@ -1,0 +1,64 @@
+import type { ScorePartwise, Note, MeasureContent } from "../types";
+
+function indent(level: number): string {
+  return "  ".repeat(level);
+}
+
+/** Serialize a ScorePartwise object into a minimal MusicXML string. */
+export function toMusicXML(score: ScorePartwise): string {
+  const lines: string[] = [];
+  const version = score.version ?? "1.0";
+  lines.push(`<score-partwise version="${version}">`);
+
+  // Part list
+  lines.push(`${indent(1)}<part-list>`);
+  for (const part of score.partList.scoreParts) {
+    lines.push(`${indent(2)}<score-part id="${part.id}">`);
+    if (part.partName) {
+      lines.push(`${indent(3)}<part-name>${part.partName}</part-name>`);
+    }
+    lines.push(`${indent(2)}</score-part>`);
+  }
+  lines.push(`${indent(1)}</part-list>`);
+
+  const isNote = (mc: MeasureContent): mc is Note =>
+    (mc as Note)._type === "note";
+
+  // Parts
+  for (const part of score.parts) {
+    lines.push(`${indent(1)}<part id="${part.id}">`);
+    for (const measure of part.measures) {
+      lines.push(`${indent(2)}<measure number="${measure.number}">`);
+      if (measure.content) {
+        for (const item of measure.content) {
+          if (isNote(item)) {
+            lines.push(`${indent(3)}<note>`);
+            if (item.pitch) {
+              lines.push(`${indent(4)}<pitch>`);
+              lines.push(`${indent(5)}<step>${item.pitch.step}</step>`);
+              if (item.pitch.alter !== undefined) {
+                lines.push(`${indent(5)}<alter>${item.pitch.alter}</alter>`);
+              }
+              lines.push(`${indent(5)}<octave>${item.pitch.octave}</octave>`);
+              lines.push(`${indent(4)}</pitch>`);
+            } else if (item.rest) {
+              lines.push(`${indent(4)}<rest/>`);
+            }
+            if (item.duration !== undefined) {
+              lines.push(`${indent(4)}<duration>${item.duration}</duration>`);
+            }
+            if (item.type) {
+              lines.push(`${indent(4)}<type>${item.type}</type>`);
+            }
+            lines.push(`${indent(3)}</note>`);
+          }
+        }
+      }
+      lines.push(`${indent(2)}</measure>`);
+    }
+    lines.push(`${indent(1)}</part>`);
+  }
+
+  lines.push(`</score-partwise>`);
+  return lines.join("\n");
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,5 @@ export * from "./parser";
 export * from "./schemas";
 export * from "./types"; // Zodから推論される型などをエクスポートするため
 export * from "./converters";
+export { toMusicXML } from "./converters";
 export * from "./utils/readMusicXmlFile";

--- a/tests/converters.test.ts
+++ b/tests/converters.test.ts
@@ -6,6 +6,7 @@ import {
   toYaml,
   toToneJsSequence,
   toMidi,
+  toMusicXML,
 } from "../src/converters";
 import { load } from "js-yaml";
 
@@ -49,5 +50,20 @@ describe("Conversion utilities", () => {
     const midi = toMidi(score);
     expect(midi.tracks.length).toBe(1);
     expect(midi.tracks[0].midi).toBe(60);
+  });
+
+  it("serializes back to MusicXML", async () => {
+    const doc = await parseMusicXmlString(xml);
+    if (!doc) throw new Error("parse failed");
+    const score = mapDocumentToScorePartwise(doc);
+    const xmlString = toMusicXML(score);
+    const parsed = await parseMusicXmlString(xmlString);
+    expect(parsed).not.toBeNull();
+    if (!parsed) return;
+    const part = parsed.querySelector("part-list score-part");
+    expect(part?.getAttribute("id")).toBe("P1");
+    const step = parsed
+      .querySelector("part measure note pitch step")?.textContent;
+    expect(step).toBe("C");
   });
 });


### PR DESCRIPTION
## Summary
- add `toMusicXML` for basic MusicXML serialization
- re-export new converter
- test round-trip conversion to MusicXML
- document `toMusicXML` and update future plans

## Testing
- `npm test`
