### PR TITLE
Add tremolo and bend attributes

### DIFF
--- a/src/parser/mappers/noteMappers.ts
+++ b/src/parser/mappers/noteMappers.ts
@@ -1042,6 +1042,10 @@ export const mapTechnicalElement = (element: Element): Technical => {
           | "above"
           | "below"
           | undefined,
+        accelerate: getAttribute(el, "accelerate") as "yes" | "no" | undefined,
+        beats: parseOptionalNumberAttribute(el, "beats"),
+        firstBeat: parseOptionalFloat(getAttribute(el, "first-beat")),
+        lastBeat: parseOptionalFloat(getAttribute(el, "last-beat")),
       }),
     );
   const taps = Array.from(element.querySelectorAll("tap"));
@@ -1108,6 +1112,13 @@ export const mapTremoloElement = (element: Element): Tremolo => {
     | "unmeasured"
     | undefined;
   if (typeAttr) tremoloData.type = typeAttr;
+  const placementAttr = getAttribute(element, "placement") as
+    | "above"
+    | "below"
+    | undefined;
+  if (placementAttr) tremoloData.placement = placementAttr;
+  const smuflAttr = getAttribute(element, "smufl");
+  if (smuflAttr) tremoloData.smufl = smuflAttr;
   return TremoloSchema.parse(tremoloData);
 };
 

--- a/src/schemas/notations.ts
+++ b/src/schemas/notations.ts
@@ -101,6 +101,8 @@ export type Slide = z.infer<typeof SlideSchema>;
 export const TremoloSchema = z.object({
   value: z.number().int(),
   type: z.enum(["single", "start", "stop", "unmeasured"]).optional(),
+  placement: z.enum(["above", "below"]).optional(),
+  smufl: z.string().optional(),
 });
 export type Tremolo = z.infer<typeof TremoloSchema>;
 
@@ -203,6 +205,10 @@ export const BendSchema = z.object({
   release: z.boolean().optional(),
   withBar: z.string().optional(),
   placement: z.enum(["above", "below"]).optional(),
+  accelerate: YesNoEnum.optional(),
+  beats: z.number().optional(),
+  firstBeat: z.number().optional(),
+  lastBeat: z.number().optional(),
 });
 export type Bend = z.infer<typeof BendSchema>;
 

--- a/tests/note.test.ts
+++ b/tests/note.test.ts
@@ -350,5 +350,27 @@ describe("Note Schema Tests (note.mod)", () => {
       expect(tech?.hammerOns?.[0].type).toBe("start");
       expect(tech?.bends?.[0].release).toBe(true);
     });
+
+    it("parses tremolo placement and smufl", () => {
+      const xml =
+        '<note><pitch><step>E</step><octave>5</octave></pitch><duration>1</duration><notations><tremolo type="single" placement="above" smufl="tremoloUnmeasured">3</tremolo></notations></note>';
+      const element = createElement(xml);
+      const note = mapNoteElement(element);
+      const trem = note.notations?.tremolos?.[0];
+      expect(trem?.placement).toBe("above");
+      expect(trem?.smufl).toBe("tremoloUnmeasured");
+    });
+
+    it("parses bend sound attributes", () => {
+      const xml =
+        '<note><pitch><step>A</step><octave>4</octave></pitch><duration>1</duration><notations><technical><bend accelerate="yes" beats="6" first-beat="30" last-beat="70"><bend-alter>1</bend-alter></bend></technical></notations></note>';
+      const element = createElement(xml);
+      const note = mapNoteElement(element);
+      const bend = note.notations?.technical?.[0]?.bends?.[0];
+      expect(bend?.accelerate).toBe("yes");
+      expect(bend?.beats).toBe(6);
+      expect(bend?.firstBeat).toBe(30);
+      expect(bend?.lastBeat).toBe(70);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- support placement and smufl attributes for tremolo
- include bend-sound attributes in technical notation
- expose the new fields when mapping MusicXML
- test tremolo placement, smufl, and bend-sound parsing

## Testing
- `npm test`