### PR TITLE
Add complete glissando/slide attributes

### DIFF
--- a/src/parser/mappers/noteMappers.ts
+++ b/src/parser/mappers/noteMappers.ts
@@ -1077,6 +1077,39 @@ export const mapGlissandoElement = (element: Element): Glissando => {
     type: getAttribute(element, "type") as "start" | "stop" | undefined,
     number: parseOptionalNumberAttribute(element, "number"),
   };
+  const orientation = getAttribute(element, "orientation");
+  if (orientation === "over" || orientation === "under")
+    glissandoData.orientation = orientation;
+  const lineTypeAttr = getAttribute(element, "line-type");
+  if (lineTypeAttr) glissandoData.lineType = lineTypeAttr;
+  const dashLenAttr = getAttribute(element, "dash-length");
+  if (dashLenAttr)
+    glissandoData.dashLength = parseOptionalFloat(dashLenAttr);
+  const spaceLenAttr = getAttribute(element, "space-length");
+  if (spaceLenAttr)
+    glissandoData.spaceLength = parseOptionalFloat(spaceLenAttr);
+  const dxAttr = getAttribute(element, "default-x");
+  if (dxAttr) glissandoData.defaultX = parseOptionalFloat(dxAttr);
+  const dyAttr = getAttribute(element, "default-y");
+  if (dyAttr) glissandoData.defaultY = parseOptionalFloat(dyAttr);
+  const rxAttr = getAttribute(element, "relative-x");
+  if (rxAttr) glissandoData.relativeX = parseOptionalFloat(rxAttr);
+  const ryAttr = getAttribute(element, "relative-y");
+  if (ryAttr) glissandoData.relativeY = parseOptionalFloat(ryAttr);
+  const colorAttr = getAttribute(element, "color");
+  if (colorAttr) glissandoData.color = colorAttr;
+  const accelAttr = getAttribute(element, "accelerate");
+  if (accelAttr === "yes" || accelAttr === "no")
+    glissandoData.accelerate = accelAttr;
+  const beatsAttr = getAttribute(element, "beats");
+  if (beatsAttr)
+    glissandoData.beats = parseOptionalFloat(beatsAttr);
+  const firstBeatAttr = getAttribute(element, "first-beat");
+  if (firstBeatAttr)
+    glissandoData.firstBeat = parseOptionalFloat(firstBeatAttr);
+  const lastBeatAttr = getAttribute(element, "last-beat");
+  if (lastBeatAttr)
+    glissandoData.lastBeat = parseOptionalFloat(lastBeatAttr);
   if (!glissandoData.type) {
     throw new Error('<glissando> element requires a "type" attribute.');
   }
@@ -1089,6 +1122,33 @@ export const mapSlideElement = (element: Element): Slide => {
     type: getAttribute(element, "type") as "start" | "stop" | undefined,
     number: parseOptionalNumberAttribute(element, "number"),
   };
+  const orientation = getAttribute(element, "orientation");
+  if (orientation === "over" || orientation === "under")
+    slideData.orientation = orientation;
+  const lineTypeAttr = getAttribute(element, "line-type");
+  if (lineTypeAttr) slideData.lineType = lineTypeAttr;
+  const dashLenAttr = getAttribute(element, "dash-length");
+  if (dashLenAttr) slideData.dashLength = parseOptionalFloat(dashLenAttr);
+  const spaceLenAttr = getAttribute(element, "space-length");
+  if (spaceLenAttr) slideData.spaceLength = parseOptionalFloat(spaceLenAttr);
+  const dxAttr = getAttribute(element, "default-x");
+  if (dxAttr) slideData.defaultX = parseOptionalFloat(dxAttr);
+  const dyAttr = getAttribute(element, "default-y");
+  if (dyAttr) slideData.defaultY = parseOptionalFloat(dyAttr);
+  const rxAttr = getAttribute(element, "relative-x");
+  if (rxAttr) slideData.relativeX = parseOptionalFloat(rxAttr);
+  const ryAttr = getAttribute(element, "relative-y");
+  if (ryAttr) slideData.relativeY = parseOptionalFloat(ryAttr);
+  const colorAttr = getAttribute(element, "color");
+  if (colorAttr) slideData.color = colorAttr;
+  const accelAttr = getAttribute(element, "accelerate");
+  if (accelAttr === "yes" || accelAttr === "no") slideData.accelerate = accelAttr;
+  const beatsAttr = getAttribute(element, "beats");
+  if (beatsAttr) slideData.beats = parseOptionalFloat(beatsAttr);
+  const firstBeatAttr = getAttribute(element, "first-beat");
+  if (firstBeatAttr) slideData.firstBeat = parseOptionalFloat(firstBeatAttr);
+  const lastBeatAttr = getAttribute(element, "last-beat");
+  if (lastBeatAttr) slideData.lastBeat = parseOptionalFloat(lastBeatAttr);
   if (!slideData.type) {
     throw new Error('<slide> element requires a "type" attribute.');
   }

--- a/src/schemas/notations.ts
+++ b/src/schemas/notations.ts
@@ -82,6 +82,19 @@ export const GlissandoSchema = z.object({
   value: z.string().optional(),
   type: z.enum(["start", "stop"]),
   number: z.number().int().optional(),
+  orientation: z.enum(["over", "under"]).optional(),
+  lineType: z.string().optional(),
+  dashLength: z.number().optional(),
+  spaceLength: z.number().optional(),
+  defaultX: z.number().optional(),
+  defaultY: z.number().optional(),
+  relativeX: z.number().optional(),
+  relativeY: z.number().optional(),
+  color: z.string().optional(),
+  accelerate: YesNoEnum.optional(),
+  beats: z.number().optional(),
+  firstBeat: z.number().optional(),
+  lastBeat: z.number().optional(),
 });
 export type Glissando = z.infer<typeof GlissandoSchema>;
 
@@ -92,6 +105,19 @@ export const SlideSchema = z.object({
   value: z.string().optional(),
   type: z.enum(["start", "stop"]),
   number: z.number().int().optional(),
+  orientation: z.enum(["over", "under"]).optional(),
+  lineType: z.string().optional(),
+  dashLength: z.number().optional(),
+  spaceLength: z.number().optional(),
+  defaultX: z.number().optional(),
+  defaultY: z.number().optional(),
+  relativeX: z.number().optional(),
+  relativeY: z.number().optional(),
+  color: z.string().optional(),
+  accelerate: YesNoEnum.optional(),
+  beats: z.number().optional(),
+  firstBeat: z.number().optional(),
+  lastBeat: z.number().optional(),
 });
 export type Slide = z.infer<typeof SlideSchema>;
 

--- a/tests/note.test.ts
+++ b/tests/note.test.ts
@@ -255,6 +255,49 @@ describe("Note Schema Tests (note.mod)", () => {
       expect(note.notations?.otherNotations?.[0].type).toBe("single");
     });
 
+    it("parses glissando with attributes", () => {
+      const xml =
+        '<note><pitch><step>C</step><octave>4</octave></pitch><duration>1</duration><notations><glissando type="start" orientation="over" line-type="dashed" dash-length="1" space-length="2" default-x="3" default-y="4" relative-x="0.5" relative-y="-0.5" color="blue" accelerate="yes" beats="6" first-beat="20" last-beat="80">gliss</glissando></notations></note>';
+      const el = createElement(xml);
+      const note = mapNoteElement(el);
+      const gl = note.notations?.glissandos?.[0]!;
+      expect(gl.orientation).toBe("over");
+      expect(gl.lineType).toBe("dashed");
+      expect(gl.dashLength).toBe(1);
+      expect(gl.spaceLength).toBe(2);
+      expect(gl.defaultX).toBe(3);
+      expect(gl.defaultY).toBe(4);
+      expect(gl.relativeX).toBe(0.5);
+      expect(gl.relativeY).toBe(-0.5);
+      expect(gl.color).toBe("blue");
+      expect(gl.accelerate).toBe("yes");
+      expect(gl.beats).toBe(6);
+      expect(gl.firstBeat).toBe(20);
+      expect(gl.lastBeat).toBe(80);
+    });
+
+    it("parses slide with bend-sound attributes", () => {
+      const xml =
+        '<note><pitch><step>C</step><octave>4</octave></pitch><duration>1</duration><notations><slide type="stop" line-type="wavy" dash-length="1.2" space-length="0.8" accelerate="no" beats="5" first-beat="10" last-beat="90" default-x="1" default-y="-1" relative-x="0" relative-y="0.2" color="red" orientation="under"/></notations></note>';
+      const el = createElement(xml);
+      const note = mapNoteElement(el);
+      const slide = note.notations?.slides?.[0]!;
+      expect(slide.type).toBe("stop");
+      expect(slide.lineType).toBe("wavy");
+      expect(slide.dashLength).toBe(1.2);
+      expect(slide.spaceLength).toBe(0.8);
+      expect(slide.accelerate).toBe("no");
+      expect(slide.beats).toBe(5);
+      expect(slide.firstBeat).toBe(10);
+      expect(slide.lastBeat).toBe(90);
+      expect(slide.defaultX).toBe(1);
+      expect(slide.defaultY).toBe(-1);
+      expect(slide.relativeX).toBe(0);
+      expect(slide.relativeY).toBe(0.2);
+      expect(slide.color).toBe("red");
+      expect(slide.orientation).toBe("under");
+    });
+
     it("parses tuplets via <time-modification>", () => {
       const xml =
         "<note><pitch><step>C</step><octave>4</octave></pitch><duration>1</duration><time-modification><actual-notes>3</actual-notes><normal-notes>2</normal-notes><normal-type>eighth</normal-type><normal-dot/></time-modification></note>";


### PR DESCRIPTION
## Summary
- extend `GlissandoSchema` and `SlideSchema` with full MusicXML attributes
- parse new glissando and slide attributes in the note mappers
- test parsing of these attributes

## Testing
- `npm test`