### PR TITLE
Expand credit formatting support

### DIFF
--- a/src/schemas/credit.ts
+++ b/src/schemas/credit.ts
@@ -8,22 +8,46 @@ export const TextFormattingSchema = z
   .object({
     justify: z.enum(["left", "center", "right"]).optional(),
     halign: z.enum(["left", "center", "right"]).optional(),
+    valign: z.enum(["top", "middle", "bottom", "baseline"]).optional(),
     defaultX: z.number().optional(),
     defaultY: z.number().optional(),
-    valign: z.enum(["top", "middle", "bottom", "baseline"]).optional(),
-    // ... other attributes like Smufl, text-decoration etc.
+    relativeX: z.number().optional(),
+    relativeY: z.number().optional(),
+    underline: z.number().optional(),
+    overline: z.number().optional(),
+    lineThrough: z.number().optional(),
+    rotation: z.number().optional(),
+    letterSpacing: z.string().optional(),
+    lineHeight: z.string().optional(),
+    dir: z.enum(["ltr", "rtl", "lro", "rlo"]).optional(),
+    enclosure: z.string().optional(),
+    xmlLang: z.string().optional(),
+    xmlSpace: z.enum(["default", "preserve"]).optional(),
     color: z.string().optional(),
   })
   .merge(FontSchema); // Include font attributes
 
 // Placeholder for symbol formatting attributes (simplified)
-export const SymbolFormattingSchema = z.object({
-  defaultX: z.number().optional(),
-  defaultY: z.number().optional(),
-  halign: z.enum(["left", "center", "right"]).optional(),
-  valign: z.enum(["top", "middle", "bottom"]).optional(),
-  // ... color, etc.
-});
+export const SymbolFormattingSchema = z
+  .object({
+    justify: z.enum(["left", "center", "right"]).optional(),
+    halign: z.enum(["left", "center", "right"]).optional(),
+    valign: z.enum(["top", "middle", "bottom"]).optional(),
+    defaultX: z.number().optional(),
+    defaultY: z.number().optional(),
+    relativeX: z.number().optional(),
+    relativeY: z.number().optional(),
+    underline: z.number().optional(),
+    overline: z.number().optional(),
+    lineThrough: z.number().optional(),
+    rotation: z.number().optional(),
+    letterSpacing: z.string().optional(),
+    lineHeight: z.string().optional(),
+    dir: z.enum(["ltr", "rtl", "lro", "rlo"]).optional(),
+    enclosure: z.string().optional(),
+    color: z.string().optional(),
+  })
+  .merge(FontSchema);
 
 export const CreditTypeSchema = z.string();
 
@@ -53,11 +77,8 @@ export const CreditSchema = z.object({
   creditTypes: z.array(CreditTypeSchema).optional(),
   links: z.array(LinkSchema).optional(),
   bookmarks: z.array(BookmarkSchema).optional(),
-  creditWords: z.array(CreditWordsSchema).optional(), // Simplified: only allowing multiple words
-  creditSymbols: z.array(CreditSymbolSchema).optional(), // Simplified
-  creditImage: CreditImageSchema.optional(), // Simplified: only one image
-  // The DTD allows a sequence of (credit-words | credit-symbol), which is hard to model directly with Zod objects for now.
-  // This simplified schema allows arrays of words, symbols, or a single image.
+  items: z.array(z.union([CreditWordsSchema, CreditSymbolSchema])).optional(),
+  creditImages: z.array(CreditImageSchema).optional(),
 });
 
 export type TextFormatting = z.infer<typeof TextFormattingSchema>;

--- a/tests/credit.test.ts
+++ b/tests/credit.test.ts
@@ -19,18 +19,20 @@ function createElement(xmlString: string): Element {
 
 describe("Credit parsing", () => {
   it("parses credit-symbol inside credit", () => {
-    const xml = `<credit page="1"><credit-type>title</credit-type><credit-symbol default-x="10" default-y="20" halign="center" valign="top">gClef</credit-symbol></credit>`;
+    const xml = `<credit page="1"><credit-type>title</credit-type><credit-symbol default-x="10" default-y="20" halign="center" valign="top" underline="1" rotation="45">gClef</credit-symbol></credit>`;
     const element = createElement(xml);
     const credit = mapCreditElement(element)!;
     expect(credit).toBeDefined();
-    expect(credit.creditSymbols).toBeDefined();
-    expect(credit.creditSymbols?.length).toBe(1);
-    const symbol = credit.creditSymbols?.[0] as CreditSymbol;
+    expect(credit.items).toBeDefined();
+    expect(credit.items?.length).toBe(1);
+    const symbol = credit.items?.[0] as CreditSymbol;
     expect(symbol.smuflGlyphName).toBe("gClef");
     expect(symbol.formatting?.defaultX).toBe(10);
     expect(symbol.formatting?.defaultY).toBe(20);
     expect(symbol.formatting?.halign).toBe("center");
     expect(symbol.formatting?.valign).toBe("top");
+    expect(symbol.formatting?.underline).toBe(1);
+    expect(symbol.formatting?.rotation).toBe(45);
   });
 
   it("parses credit link", () => {
@@ -59,8 +61,9 @@ describe("Credit parsing", () => {
     const xml = `<credit><credit-image source="cover.png" type="image/png" height="25" width="80" default-x="10" default-y="-5" halign="right" valign="bottom"/></credit>`;
     const element = createElement(xml);
     const credit = mapCreditElement(element)!;
-    expect(credit.creditImage).toBeDefined();
-    const image = credit.creditImage as CreditImage;
+    expect(credit.creditImages).toBeDefined();
+    expect(credit.creditImages?.length).toBe(1);
+    const image = credit.creditImages?.[0] as CreditImage;
     expect(image.source).toBe("cover.png");
     expect(image.type).toBe("image/png");
     expect(image.height).toBe(25);
@@ -69,5 +72,25 @@ describe("Credit parsing", () => {
     expect(image.defaultY).toBe(-5);
     expect(image.halign).toBe("right");
     expect(image.valign).toBe("bottom");
+  });
+
+  it("parses mixed credit content and formatting", () => {
+    const xml = `<credit page="2">
+      <credit-words underline="2">Hello</credit-words>
+      <credit-symbol rotation="-30">fClef</credit-symbol>
+      <credit-words overline="1">World</credit-words>
+    </credit>`;
+    const element = createElement(xml);
+    const credit = mapCreditElement(element)!;
+    expect(credit.items?.length).toBe(3);
+    const w1 = credit.items?.[0] as any;
+    const s = credit.items?.[1] as any;
+    const w2 = credit.items?.[2] as any;
+    expect(w1.text).toBe("Hello");
+    expect(w1.formatting?.underline).toBe(2);
+    expect(s.smuflGlyphName).toBe("fClef");
+    expect(s.formatting?.rotation).toBe(-30);
+    expect(w2.text).toBe("World");
+    expect(w2.formatting?.overline).toBe(1);
   });
 });

--- a/tests/echigo-jishi.test.ts
+++ b/tests/echigo-jishi.test.ts
@@ -5,7 +5,6 @@ import { parseMusicXmlString } from "../src/parser/xmlParser";
 import { mapDocumentToScorePartwise } from "../src/parser/mappers";
 import type {
   ScorePartwise,
-  CreditWords,
   Measure,
   Note,
   Attributes,
@@ -183,19 +182,20 @@ describe("Echigo-Jishi.musicxml Parser Test", () => {
     const titleCredit = scorePartwise.credit?.find(
       (c: Credit) =>
         c.creditTypes?.includes("title") &&
-        c.creditWords?.[0]?.text === "越後獅子",
+        c.items?.[0] && (c.items[0] as any).text === "越後獅子",
     );
     expect(titleCredit).toBeDefined();
     expect(titleCredit?.page).toBe("1");
-    expect(titleCredit?.creditWords?.[0].formatting?.defaultX).toBe(607);
-    expect(titleCredit?.creditWords?.[0].formatting?.defaultY).toBe(1443);
-    expect(titleCredit?.creditWords?.[0].formatting?.fontFamily).toBe(
+    const firstItem = titleCredit?.items?.[0] as any;
+    expect(firstItem.formatting?.defaultX).toBe(607);
+    expect(firstItem.formatting?.defaultY).toBe(1443);
+    expect(firstItem.formatting?.fontFamily).toBe(
       "ＭＳ ゴシック",
     );
-    expect(titleCredit?.creditWords?.[0].formatting?.fontSize).toBe("24");
-    expect(titleCredit?.creditWords?.[0].formatting?.fontWeight).toBe("bold");
-    expect(titleCredit?.creditWords?.[0].formatting?.justify).toBe("center");
-    expect(titleCredit?.creditWords?.[0].formatting?.valign).toBe("top");
+    expect(firstItem.formatting?.fontSize).toBe("24");
+    expect(firstItem.formatting?.fontWeight).toBe("bold");
+    expect(firstItem.formatting?.justify).toBe("center");
+    expect(firstItem.formatting?.valign).toBe("top");
     // xml:lang is not directly in CreditWordsSchema.textFormatting, but on credit-words element itself.
     // Our current schema/mapper for credit-words doesn't capture xml:lang on credit-words directly.
 
@@ -203,20 +203,22 @@ describe("Echigo-Jishi.musicxml Parser Test", () => {
       c.creditTypes?.includes("arranger"),
     );
     expect(arrangerCredit).toBeDefined();
-    expect(arrangerCredit?.creditWords?.[0].text).toBe(
+    const arrangerItem = arrangerCredit?.items?.[0] as any;
+    expect(arrangerItem.text).toBe(
       "Arr. Y. Nagai , K. Kobatake",
     );
-    expect(arrangerCredit?.creditWords?.[0].formatting?.defaultX).toBe(1124);
-    expect(arrangerCredit?.creditWords?.[0].formatting?.justify).toBe("right");
+    expect(arrangerItem.formatting?.defaultX).toBe(1124);
+    expect(arrangerItem.formatting?.justify).toBe("right");
 
     const rightsCredit = scorePartwise.credit?.find((c: Credit) =>
       c.creditTypes?.includes("rights"),
     );
     expect(rightsCredit).toBeDefined();
-    expect(rightsCredit?.creditWords?.[0].text).toBe(
+    const rightsItem = rightsCredit?.items?.[0] as any;
+    expect(rightsItem.text).toBe(
       "Transcription donated to the public domain, 2005 by Tom Potter",
     );
-    expect(rightsCredit?.creditWords?.[0].formatting?.justify).toBe("center");
+    expect(rightsItem.formatting?.justify).toBe("center");
   });
 
   it("should parse part-list and score-part (basic check)", () => {


### PR DESCRIPTION
## Summary
- support full MusicXML text/symbol formatting attributes
- keep `<credit>` content order and allow multiple images
- update credit mappers and tests for new schema

## Testing
- `npm test`