### PR TITLE
Support more direction symbols

### DIFF
--- a/src/parser/mappers/noteMappers.ts
+++ b/src/parser/mappers/noteMappers.ts
@@ -132,6 +132,18 @@ import type {
   Dashes,
   Bracket,
   Image,
+  Eyeglasses,
+  Damp,
+  DampAll,
+  StringMute,
+  HarpPedals,
+  PedalTuning,
+  Accord,
+  Scordatura,
+  PrincipalVoice,
+  AccordionRegistration,
+  StaffDivide,
+  OtherDirection,
 } from "../../types";
 import {
   PitchSchema,
@@ -243,6 +255,18 @@ import {
   DashesSchema,
   BracketSchema,
   ImageSchema,
+  EyeglassesSchema,
+  DampSchema,
+  DampAllSchema,
+  StringMuteSchema,
+  HarpPedalsSchema,
+  PedalTuningSchema,
+  AccordSchema,
+  ScordaturaSchema,
+  PrincipalVoiceSchema,
+  AccordionRegistrationSchema,
+  StaffDivideSchema,
+  OtherDirectionSchema,
   GroupSymbolValueEnum,
   RootSchema,
   KindSchema,
@@ -1446,6 +1470,102 @@ export const mapImageElement = (element: Element): Image | undefined => {
   return ImageSchema.parse(data);
 };
 
+export const mapEyeglassesElement = (_element: Element): Eyeglasses => {
+  return EyeglassesSchema.parse({});
+};
+
+export const mapDampElement = (_element: Element): Damp => {
+  return DampSchema.parse({});
+};
+
+export const mapDampAllElement = (_element: Element): DampAll => {
+  return DampAllSchema.parse({});
+};
+
+export const mapStringMuteElement = (element: Element): StringMute => {
+  const typeAttr = getAttribute(element, "type") as "on" | "off" | undefined;
+  return StringMuteSchema.parse({ type: typeAttr });
+};
+
+export const mapPedalTuningElement = (element: Element): PedalTuning => {
+  const data: Partial<PedalTuning> = {
+    "pedal-step": getTextContent(element, "pedal-step") ?? "",
+  };
+  const alt = parseFloatContent(element, "pedal-alter");
+  if (alt !== undefined) data["pedal-alter"] = alt;
+  return PedalTuningSchema.parse(data);
+};
+
+export const mapHarpPedalsElement = (element: Element): HarpPedals => {
+  const tunings = Array.from(element.querySelectorAll("pedal-tuning")).map(
+    mapPedalTuningElement,
+  );
+  return HarpPedalsSchema.parse({ "pedal-tuning": tunings });
+};
+
+export const mapAccordElement = (element: Element): Accord => {
+  const data: Partial<Accord> = {
+    "tuning-step": getTextContent(element, "tuning-step") ?? "",
+    "tuning-octave": parseNumberContent(element, "tuning-octave") ?? 0,
+  };
+  const alt = parseFloatContent(element, "tuning-alter");
+  if (alt !== undefined) data["tuning-alter"] = alt;
+  const stringAttr = getAttribute(element, "string");
+  if (stringAttr) data.string = stringAttr;
+  return AccordSchema.parse(data);
+};
+
+export const mapScordaturaElement = (element: Element): Scordatura => {
+  const accords = Array.from(element.querySelectorAll("accord")).map(
+    mapAccordElement,
+  );
+  return ScordaturaSchema.parse({ accord: accords });
+};
+
+export const mapPrincipalVoiceElement = (element: Element): PrincipalVoice => {
+  const data: Partial<PrincipalVoice> = {
+    text: element.textContent?.trim() ?? "",
+  };
+  const typeAttr = getAttribute(element, "type") as
+    | "start"
+    | "stop"
+    | undefined;
+  if (typeAttr) data.type = typeAttr;
+  const symbolAttr = getAttribute(element, "symbol") as
+    | "Hauptstimme"
+    | "Nebenstimme"
+    | "plain"
+    | "none"
+    | undefined;
+  if (symbolAttr) data.symbol = symbolAttr;
+  return PrincipalVoiceSchema.parse(data);
+};
+
+export const mapAccordionRegistrationElement = (
+  element: Element,
+): AccordionRegistration => {
+  const data: Partial<AccordionRegistration> = {};
+  if (element.querySelector("accordion-high")) data["accordion-high"] = true;
+  const midEl = element.querySelector("accordion-middle");
+  if (midEl) data["accordion-middle"] = midEl.textContent?.trim() ?? "";
+  if (element.querySelector("accordion-low")) data["accordion-low"] = true;
+  return AccordionRegistrationSchema.parse(data);
+};
+
+export const mapStaffDivideElement = (element: Element): StaffDivide => {
+  const typeAttr = getAttribute(element, "type") as
+    | "down"
+    | "up"
+    | "up-down"
+    | undefined;
+  return StaffDivideSchema.parse({ type: typeAttr });
+};
+
+export const mapOtherDirectionElement = (element: Element): OtherDirection => {
+  const text = element.textContent?.trim() ?? "";
+  return OtherDirectionSchema.parse({ text });
+};
+
 // Helper function to map a <beat-unit> element (within <metronome>)
 export const mapMetronomeBeatUnitElement = (
   element: Element,
@@ -1547,6 +1667,16 @@ export const mapDirectionTypeElement = (element: Element): DirectionType => {
   const dashesElement = element.querySelector("dashes");
   const bracketElement = element.querySelector("bracket");
   const imageElement = element.querySelector("image");
+  const eyeglassesElement = element.querySelector("eyeglasses");
+  const dampElement = element.querySelector("damp");
+  const dampAllElement = element.querySelector("damp-all");
+  const stringMuteElement = element.querySelector("string-mute");
+  const harpPedalsElement = element.querySelector("harp-pedals");
+  const scordaturaElement = element.querySelector("scordatura");
+  const principalVoiceElement = element.querySelector("principal-voice");
+  const accordionRegElement = element.querySelector("accordion-registration");
+  const staffDivideElement = element.querySelector("staff-divide");
+  const otherDirectionElement = element.querySelector("other-direction");
   const directionTypeData: Partial<DirectionType> = {};
   if (wordsElement) {
     directionTypeData.words = mapWordsElement(wordsElement);
@@ -1651,6 +1781,41 @@ export const mapDirectionTypeElement = (element: Element): DirectionType => {
   }
   if (bracketElement) {
     directionTypeData.bracket = mapBracketElement(bracketElement);
+  }
+  if (eyeglassesElement) {
+    directionTypeData.eyeglasses = mapEyeglassesElement(eyeglassesElement);
+  }
+  if (dampElement) {
+    directionTypeData.damp = mapDampElement(dampElement);
+  }
+  if (dampAllElement) {
+    directionTypeData.dampAll = mapDampAllElement(dampAllElement);
+  }
+  if (stringMuteElement) {
+    directionTypeData.stringMute = mapStringMuteElement(stringMuteElement);
+  }
+  if (harpPedalsElement) {
+    directionTypeData.harpPedals = mapHarpPedalsElement(harpPedalsElement);
+  }
+  if (scordaturaElement) {
+    directionTypeData.scordatura = mapScordaturaElement(scordaturaElement);
+  }
+  if (principalVoiceElement) {
+    directionTypeData.principalVoice = mapPrincipalVoiceElement(
+      principalVoiceElement,
+    );
+  }
+  if (accordionRegElement) {
+    directionTypeData.accordionRegistration =
+      mapAccordionRegistrationElement(accordionRegElement);
+  }
+  if (staffDivideElement) {
+    directionTypeData.staffDivide = mapStaffDivideElement(staffDivideElement);
+  }
+  if (otherDirectionElement) {
+    directionTypeData.otherDirection = mapOtherDirectionElement(
+      otherDirectionElement,
+    );
   }
   if (imageElement) {
     const img = mapImageElement(imageElement);

--- a/src/schemas/direction.ts
+++ b/src/schemas/direction.ts
@@ -140,6 +140,68 @@ export type Bracket = z.infer<typeof BracketSchema>;
 export const ImageSchema = CreditImageSchema;
 export type Image = z.infer<typeof ImageSchema>;
 
+export const EyeglassesSchema = z.object({});
+export type Eyeglasses = z.infer<typeof EyeglassesSchema>;
+
+export const DampSchema = z.object({});
+export type Damp = z.infer<typeof DampSchema>;
+
+export const DampAllSchema = z.object({});
+export type DampAll = z.infer<typeof DampAllSchema>;
+
+export const StringMuteSchema = z.object({
+  type: z.enum(["on", "off"]).optional(),
+});
+export type StringMute = z.infer<typeof StringMuteSchema>;
+
+export const PedalTuningSchema = z.object({
+  "pedal-step": z.string(),
+  "pedal-alter": z.number().optional(),
+});
+export type PedalTuning = z.infer<typeof PedalTuningSchema>;
+
+export const HarpPedalsSchema = z.object({
+  "pedal-tuning": z.array(PedalTuningSchema),
+});
+export type HarpPedals = z.infer<typeof HarpPedalsSchema>;
+
+export const AccordSchema = z.object({
+  string: z.string().optional(),
+  "tuning-step": z.string(),
+  "tuning-alter": z.number().optional(),
+  "tuning-octave": z.number(),
+});
+export type Accord = z.infer<typeof AccordSchema>;
+
+export const ScordaturaSchema = z.object({
+  accord: z.array(AccordSchema),
+});
+export type Scordatura = z.infer<typeof ScordaturaSchema>;
+
+export const PrincipalVoiceSchema = z.object({
+  type: z.enum(["start", "stop"]).optional(),
+  symbol: z.enum(["Hauptstimme", "Nebenstimme", "plain", "none"]).optional(),
+  text: z.string().optional(),
+});
+export type PrincipalVoice = z.infer<typeof PrincipalVoiceSchema>;
+
+export const AccordionRegistrationSchema = z.object({
+  "accordion-high": z.boolean().optional(),
+  "accordion-middle": z.string().optional(),
+  "accordion-low": z.boolean().optional(),
+});
+export type AccordionRegistration = z.infer<typeof AccordionRegistrationSchema>;
+
+export const StaffDivideSchema = z.object({
+  type: z.enum(["down", "up", "up-down"]).optional(),
+});
+export type StaffDivide = z.infer<typeof StaffDivideSchema>;
+
+export const OtherDirectionSchema = z.object({
+  text: z.string(),
+});
+export type OtherDirection = z.infer<typeof OtherDirectionSchema>;
+
 /**
  * Represents the <direction-type> element, which contains the actual content of a direction.
  */
@@ -156,6 +218,16 @@ export const DirectionTypeSchema = z.object({
   dashes: DashesSchema.optional(),
   bracket: BracketSchema.optional(),
   image: ImageSchema.optional(),
+  eyeglasses: EyeglassesSchema.optional(),
+  damp: DampSchema.optional(),
+  dampAll: DampAllSchema.optional(),
+  stringMute: StringMuteSchema.optional(),
+  harpPedals: HarpPedalsSchema.optional(),
+  scordatura: ScordaturaSchema.optional(),
+  principalVoice: PrincipalVoiceSchema.optional(),
+  accordionRegistration: AccordionRegistrationSchema.optional(),
+  staffDivide: StaffDivideSchema.optional(),
+  otherDirection: OtherDirectionSchema.optional(),
 });
 export type DirectionType = z.infer<typeof DirectionTypeSchema>;
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -35,6 +35,18 @@ export type {
   Dashes,
   Bracket,
   Image,
+  Eyeglasses,
+  Damp,
+  DampAll,
+  StringMute,
+  HarpPedals,
+  PedalTuning,
+  Scordatura,
+  Accord,
+  PrincipalVoice,
+  AccordionRegistration,
+  StaffDivide,
+  OtherDirection,
 } from "../schemas/direction";
 
 export type {

--- a/tests/direction.test.ts
+++ b/tests/direction.test.ts
@@ -154,4 +154,48 @@ describe("Direction parsing", () => {
     const direction = mapDirectionElement(el);
     expect(direction.offset).toBe(2.5);
   });
+
+  it("parses eyeglasses and damping elements", () => {
+    const xml = `<direction><direction-type><eyeglasses/><damp/><damp-all/></direction-type></direction>`;
+    const el = createElement(xml);
+    const direction = mapDirectionElement(el);
+    const dt = direction.direction_type[0];
+    expect(dt.eyeglasses).toBeDefined();
+    expect(dt.damp).toBeDefined();
+    expect(dt.dampAll).toBeDefined();
+  });
+
+  it("parses string-mute element", () => {
+    const xml = `<direction><direction-type><string-mute type="on"/></direction-type></direction>`;
+    const el = createElement(xml);
+    const direction = mapDirectionElement(el);
+    expect(direction.direction_type[0].stringMute?.type).toBe("on");
+  });
+
+  it("parses harp-pedals element", () => {
+    const xml = `<direction><direction-type><harp-pedals><pedal-tuning><pedal-step>D</pedal-step><pedal-alter>-1</pedal-alter></pedal-tuning><pedal-tuning><pedal-step>E</pedal-step></pedal-tuning></harp-pedals></direction-type></direction>`;
+    const el = createElement(xml);
+    const direction = mapDirectionElement(el);
+    const hp = direction.direction_type[0].harpPedals!;
+    expect(hp["pedal-tuning"].length).toBe(2);
+    expect(hp["pedal-tuning"][0]["pedal-step"]).toBe("D");
+    expect(hp["pedal-tuning"][0]["pedal-alter"]).toBe(-1);
+  });
+
+  it("parses scordatura element", () => {
+    const xml = `<direction><direction-type><scordatura><accord string="1"><tuning-step>A</tuning-step><tuning-octave>4</tuning-octave></accord></scordatura></direction-type></direction>`;
+    const el = createElement(xml);
+    const direction = mapDirectionElement(el);
+    const sc = direction.direction_type[0].scordatura!;
+    expect(sc.accord.length).toBe(1);
+    expect(sc.accord[0]["tuning-step"]).toBe("A");
+    expect(sc.accord[0].string).toBe("1");
+  });
+
+  it("parses other-direction element", () => {
+    const xml = `<direction><direction-type><other-direction>custom</other-direction></direction-type></direction>`;
+    const el = createElement(xml);
+    const direction = mapDirectionElement(el);
+    expect(direction.direction_type[0].otherDirection?.text).toBe("custom");
+  });
 });


### PR DESCRIPTION
## Summary
- add schemas for eyeglasses, damp, harp pedals and more
- export new direction types
- parse new direction-type elements in note mapper
- test parsing of new direction symbols

## Testing
- `npm test`
- `npm run format:check`
- `npm run lint` (warnings expected)
