### PR TITLE
Add advanced tests for directions, ornaments and credit

### DIFF
--- a/src/parser/mappers/noteMappers.ts
+++ b/src/parser/mappers/noteMappers.ts
@@ -1077,6 +1077,9 @@ export const mapGlissandoElement = (element: Element): Glissando => {
     type: getAttribute(element, "type") as "start" | "stop" | undefined,
     number: parseOptionalNumberAttribute(element, "number"),
   };
+  const orientAttr = getAttribute(element, "orientation");
+  if (orientAttr === "up" || orientAttr === "down")
+    glissandoData.orientation = orientAttr;
   if (!glissandoData.type) {
     throw new Error('<glissando> element requires a "type" attribute.');
   }

--- a/src/schemas/notations.ts
+++ b/src/schemas/notations.ts
@@ -82,6 +82,7 @@ export const GlissandoSchema = z.object({
   value: z.string().optional(),
   type: z.enum(["start", "stop"]),
   number: z.number().int().optional(),
+  orientation: UpDownEnum.optional(),
 });
 export type Glissando = z.infer<typeof GlissandoSchema>;
 

--- a/tests/creditDetailed.test.ts
+++ b/tests/creditDetailed.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { JSDOM } from "jsdom";
+import { mapCreditElement } from "../src/parser/mappers";
+import type { CreditWords, CreditSymbol, CreditImage, Link, Bookmark } from "../src/types";
+
+function createElement(xmlString: string): Element {
+  const dom = new JSDOM(xmlString, { contentType: "application/xml" });
+  const parsererror = dom.window.document.querySelector("parsererror");
+  if (parsererror) throw new Error("Invalid XML");
+  return dom.window.document.documentElement;
+}
+
+describe("Detailed Credit parsing", () => {
+  it("parses mixed credit elements", () => {
+    const xml = `<credit page="1">
+      <credit-type>title</credit-type>
+      <credit-type>subtitle</credit-type>
+      <link href="http://example.com"/>
+      <bookmark id="b1" name="start"/>
+      <credit-words default-x="5" default-y="10" halign="center">Hello</credit-words>
+      <credit-words font-weight="bold">World</credit-words>
+      <credit-symbol default-x="1">gClef</credit-symbol>
+      <credit-image source="img.png" type="image/png" width="100" height="50"/>
+    </credit>`;
+    const el = createElement(xml);
+    const credit = mapCreditElement(el)!;
+    expect(credit.page).toBe("1");
+    expect(credit.creditTypes?.length).toBe(2);
+    expect(credit.links?.length).toBe(1);
+    expect(credit.bookmarks?.length).toBe(1);
+    expect(credit.creditWords?.length).toBe(2);
+    const w1 = credit.creditWords?.[0] as CreditWords;
+    expect(w1.text).toBe("Hello");
+    expect(w1.formatting?.defaultX).toBe(5);
+    expect(w1.formatting?.justify).toBe("center");
+    const w2 = credit.creditWords?.[1] as CreditWords;
+    expect(w2.text).toBe("World");
+    expect(w2.formatting?.fontWeight).toBe("bold");
+    const symbol = credit.creditSymbols?.[0] as CreditSymbol;
+    expect(symbol.smuflGlyphName).toBe("gClef");
+    expect(symbol.formatting?.defaultX).toBe(1);
+    const image = credit.creditImage as CreditImage;
+    expect(image.width).toBe(100);
+    expect(image.height).toBe(50);
+  });
+});
+

--- a/tests/directionAdvanced.test.ts
+++ b/tests/directionAdvanced.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { JSDOM } from "jsdom";
+import { mapDirectionElement } from "../src/parser/mappers";
+
+function createElement(xmlString: string): Element {
+  const dom = new JSDOM(xmlString, { contentType: "application/xml" });
+  const err = dom.window.document.querySelector("parsererror");
+  if (err) throw new Error("Invalid XML");
+  return dom.window.document.documentElement;
+}
+
+describe("Advanced Direction parsing", () => {
+  it("parses multiple direction-type elements and wedge attributes", () => {
+    const xml = `<direction placement="below" staff="2">
+      <direction-type><words font-style="italic">rit.</words></direction-type>
+      <direction-type><wedge type="diminuendo" number="2" spread="11" niente="no" line-type="dotted" dash-length="1.1" space-length="2" default-x="1" default-y="-1" relative-x="0.5" relative-y="0" color="green" id="w2"/></direction-type>
+      <sound dynamics="70"/>
+      <offset>-0.5</offset>
+    </direction>`;
+    const el = createElement(xml);
+    const direction = mapDirectionElement(el);
+    expect(direction.placement).toBe("below");
+    expect(direction.staff).toBe(2);
+    expect(direction.direction_type.length).toBe(2);
+    expect(direction.direction_type[0].words?.text).toBe("rit.");
+    const wedge = direction.direction_type[1].wedge!;
+    expect(wedge.type).toBe("diminuendo");
+    expect(wedge.number).toBe(2);
+    expect(wedge.spread).toBe(11);
+    expect(wedge.niente).toBe("no");
+    expect(wedge.lineType).toBe("dotted");
+    expect(wedge.dashLength).toBe(1.1);
+    expect(wedge.spaceLength).toBe(2);
+    expect(wedge.defaultX).toBe(1);
+    expect(wedge.defaultY).toBe(-1);
+    expect(wedge.relativeX).toBe(0.5);
+    expect(wedge.relativeY).toBe(0);
+    expect(wedge.color).toBe("green");
+    expect(wedge.id).toBe("w2");
+    expect(direction.sound?.dynamics).toBe(70);
+    expect(direction.offset).toBe(-0.5);
+  });
+});
+

--- a/tests/ornamentsComplex.test.ts
+++ b/tests/ornamentsComplex.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { JSDOM } from "jsdom";
+import { mapNoteElement } from "../src/parser/mappers";
+import type { Glissando, Ornaments } from "../src/types";
+
+function createElement(xmlString: string): Element {
+  const dom = new JSDOM(xmlString, { contentType: "application/xml" });
+  const err = dom.window.document.querySelector("parsererror");
+  if (err) throw new Error("Invalid XML");
+  return dom.window.document.documentElement;
+}
+
+describe("Complex ornaments parsing", () => {
+  it("parses glissando with orientation and detailed ornaments", () => {
+    const xml = `<note><pitch><step>A</step><octave>4</octave></pitch><duration>1</duration><notations>
+      <glissando type="start" orientation="up" number="2">gliss</glissando>
+      <ornaments>
+        <mordent long="yes" approach="above" departure="below"/>
+        <wavy-line type="start" accelerate="yes" beats="2" second-beats="1" last-beat="3" placement="below" color="red"/>
+        <other-ornament smufl="ornamentX">X</other-ornament>
+      </ornaments>
+    </notations></note>`;
+    const el = createElement(xml);
+    const note = mapNoteElement(el);
+    const gliss = note.notations?.glissandos?.[0] as Glissando;
+    expect(gliss.type).toBe("start");
+    expect(gliss.orientation).toBe("up");
+    expect(gliss.number).toBe(2);
+    const orn = note.notations?.ornaments?.[0] as Ornaments;
+    expect(orn.mordents?.[0].long).toBe("yes");
+    expect(orn.mordents?.[0].approach).toBe("above");
+    expect(orn.mordents?.[0].departure).toBe("below");
+    const wavy = orn.wavyLines?.[0]!;
+    expect(wavy.type).toBe("start");
+    expect(wavy.accelerate).toBe("yes");
+    expect(wavy.beats).toBe(2);
+    expect(wavy.secondBeats).toBe(1);
+    expect(wavy.lastBeat).toBe(3);
+    expect(wavy.placement).toBe("below");
+    expect(wavy.color).toBe("red");
+    expect(orn.otherOrnaments?.[0].smufl).toBe("ornamentX");
+  });
+});
+


### PR DESCRIPTION
## Summary
- add `orientation` support for glissando
- test complex credit element combos
- test advanced direction cases with wedge attributes
- test glissando orientation and detailed ornaments

## Testing
- `npm test`