### PR TITLE
Add movement number and instrument handling

### DIFF
--- a/src/parser/mappers/measureMappers.ts
+++ b/src/parser/mappers/measureMappers.ts
@@ -1477,6 +1477,7 @@ export const mapDocumentToScorePartwise = (doc: XMLDocument): ScorePartwise => {
 
   const workElement = rootElement.querySelector("work");
   const movementTitleElement = rootElement.querySelector("movement-title");
+  const movementNumberElement = rootElement.querySelector("movement-number");
   const identificationElement = rootElement.querySelector("identification");
   const defaultsElement = rootElement.querySelector("defaults");
   const creditElements = Array.from(rootElement.querySelectorAll("credit"));
@@ -1498,6 +1499,10 @@ export const mapDocumentToScorePartwise = (doc: XMLDocument): ScorePartwise => {
   }
   if (movementTitleElement) {
     scorePartwiseData.movementTitle = movementTitleElement.textContent?.trim();
+  }
+  if (movementNumberElement) {
+    scorePartwiseData.movementNumber =
+      movementNumberElement.textContent?.trim();
   }
   if (identificationElement) {
     scorePartwiseData.identification = mapIdentificationElement(
@@ -1537,6 +1542,7 @@ export const mapDocumentToScoreTimewise = (doc: XMLDocument): ScoreTimewise => {
 
   const workElement = rootElement.querySelector("work");
   const movementTitleElement = rootElement.querySelector("movement-title");
+  const movementNumberElement = rootElement.querySelector("movement-number");
   const identificationElement = rootElement.querySelector("identification");
   const defaultsElement = rootElement.querySelector("defaults");
   const creditElements = Array.from(rootElement.querySelectorAll("credit"));
@@ -1558,6 +1564,10 @@ export const mapDocumentToScoreTimewise = (doc: XMLDocument): ScoreTimewise => {
   }
   if (movementTitleElement) {
     scoreTimewiseData.movementTitle = movementTitleElement.textContent?.trim();
+  }
+  if (movementNumberElement) {
+    scoreTimewiseData.movementNumber =
+      movementNumberElement.textContent?.trim();
   }
   if (identificationElement) {
     scoreTimewiseData.identification = mapIdentificationElement(

--- a/src/parser/mappers/noteMappers.ts
+++ b/src/parser/mappers/noteMappers.ts
@@ -535,6 +535,7 @@ export const mapNoteElement = (element: Element): Note => {
   const tieElements = Array.from(element.querySelectorAll("tie"));
   const timeModElement = element.querySelector("time-modification");
   const voiceContent = getTextContent(element, "voice");
+  const instrumentElement = element.querySelector("instrument");
 
   const noteData: Partial<Note> = {
     _type: "note",
@@ -546,6 +547,8 @@ export const mapNoteElement = (element: Element): Note => {
     | "yes"
     | "no"
     | undefined;
+  const printObjectAttr = getAttribute(element, "print-object");
+  if (printObjectAttr) noteData.printObject = printObjectAttr as "yes" | "no";
   const dynamicsAttr = getAttribute(element, "dynamics");
   if (dynamicsAttr) noteData.dynamics = parseFloat(dynamicsAttr);
   const endDynamicsAttr = getAttribute(element, "end-dynamics");
@@ -614,6 +617,11 @@ export const mapNoteElement = (element: Element): Note => {
   }
   if (voiceContent) {
     noteData.voice = voiceContent;
+  }
+  if (instrumentElement) {
+    const id = getAttribute(instrumentElement, "id");
+    const text = instrumentElement.textContent?.trim();
+    noteData.instrument = id || text || undefined;
   }
 
   try {

--- a/src/schemas/note.ts
+++ b/src/schemas/note.ts
@@ -37,6 +37,8 @@ export const NoteSchema = z
     beams: z.array(BeamSchema).optional(),
     notations: NotationsSchema.optional(),
     lyrics: z.array(LyricSchema).optional(),
+    instrument: z.string().optional(),
+    printObject: z.enum(["yes", "no"]).optional(),
     printLeger: z.enum(["yes", "no"]).optional(),
     dynamics: z.number().optional(),
     endDynamics: z.number().optional(),

--- a/src/schemas/scorePartwise.ts
+++ b/src/schemas/scorePartwise.ts
@@ -31,6 +31,8 @@ export const ScorePartwiseSchema: z.ZodType<any> = z
     work: WorkSchema.optional(),
     /** Movement title. */
     movementTitle: z.string().optional(),
+    /** Movement number. */
+    movementNumber: z.string().optional(),
     /** Identification of creators, encoding, etc. */
     identification: IdentificationSchema.optional(),
     /** Score-wide defaults for layout, appearance, and MIDI. */

--- a/src/schemas/scoreTimewise.ts
+++ b/src/schemas/scoreTimewise.ts
@@ -11,6 +11,7 @@ export const ScoreTimewiseMetadataSchema = z.object({
   version: z.string().optional().default("1.0"),
   work: WorkSchema.optional(),
   movementTitle: z.string().optional(),
+  movementNumber: z.string().optional(),
   identification: IdentificationSchema.optional(),
   defaults: DefaultsSchema.optional(),
   credit: z.array(CreditSchema).optional(),

--- a/tests/movementNumber.test.ts
+++ b/tests/movementNumber.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { parseMusicXmlString } from "../src/parser/xmlParser";
+import {
+  mapDocumentToScorePartwise,
+  mapDocumentToScoreTimewise,
+} from "../src/parser/mappers";
+
+const partwiseXml = `
+<score-partwise version="3.1">
+  <movement-number>1</movement-number>
+  <part-list>
+    <score-part id="P1" />
+  </part-list>
+  <part id="P1"><measure number="1"/></part>
+</score-partwise>`;
+
+const timewiseXml = `
+<score-timewise version="3.1">
+  <movement-number>2</movement-number>
+  <part-list>
+    <score-part id="P1" />
+  </part-list>
+  <measure number="1">
+    <part id="P1" />
+  </measure>
+</score-timewise>`;
+
+describe("movement-number parsing", () => {
+  it("maps movement-number in score-partwise", async () => {
+    const doc = await parseMusicXmlString(partwiseXml);
+    expect(doc).not.toBeNull();
+    if (!doc) return;
+    const score = mapDocumentToScorePartwise(doc);
+    expect(score.movementNumber).toBe("1");
+  });
+
+  it("maps movement-number in score-timewise", async () => {
+    const doc = await parseMusicXmlString(timewiseXml);
+    expect(doc).not.toBeNull();
+    if (!doc) return;
+    const score = mapDocumentToScoreTimewise(doc);
+    expect(score.movementNumber).toBe("2");
+  });
+});

--- a/tests/note.test.ts
+++ b/tests/note.test.ts
@@ -415,5 +415,14 @@ describe("Note Schema Tests (note.mod)", () => {
       expect(bend?.firstBeat).toBe(30);
       expect(bend?.lastBeat).toBe(70);
     });
+
+    it("maps instrument and print-object on note", () => {
+      const xml =
+        '<note print-object="no"><instrument id="P1-I1"/>\n<pitch><step>C</step><octave>4</octave></pitch><duration>1</duration></note>';
+      const element = createElement(xml);
+      const note = mapNoteElement(element);
+      expect(note.instrument).toBe("P1-I1");
+      expect(note.printObject).toBe("no");
+    });
   });
 });


### PR DESCRIPTION
## Summary
- support `<movement-number>` in score schemas and mappers
- include instrument and print-object on notes
- parse note instrument id
- test movement number mapping and new note fields

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`