### PR TITLE
Add notehead-text schema and mapping

### DIFF
--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -56,3 +56,4 @@ export * from "./bookmark";
 export * from "./scoreInstrument";
 export * from "./midiDevice";
 export * from "./midiInstrument";
+export * from "./noteheadText";

--- a/src/schemas/note.ts
+++ b/src/schemas/note.ts
@@ -11,6 +11,7 @@ import { GraceSchema } from "./grace";
 import { CueSchema } from "./cue";
 import { UnpitchedSchema } from "./unpitched";
 import { TimeModificationSchema } from "./timeModification";
+import { NoteheadTextSchema } from "./noteheadText";
 
 /**
  * Represents a single musical note or rest.
@@ -35,6 +36,7 @@ export const NoteSchema = z
     accidental: AccidentalSchema.optional(),
     stem: StemSchema.optional(),
     beams: z.array(BeamSchema).optional(),
+    noteheadText: z.array(NoteheadTextSchema).optional(),
     notations: NotationsSchema.optional(),
     lyrics: z.array(LyricSchema).optional(),
     instrument: z.string().optional(),

--- a/src/schemas/noteheadText.ts
+++ b/src/schemas/noteheadText.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+import { TextFormattingSchema } from "./credit";
+import { AccidentalSchema } from "./accidental";
+
+export const DisplayTextSchema = z.object({
+  text: z.string(),
+  formatting: TextFormattingSchema.optional(),
+});
+export type DisplayText = z.infer<typeof DisplayTextSchema>;
+
+export const AccidentalTextSchema = z.object({
+  value: AccidentalSchema.shape.value,
+  formatting: TextFormattingSchema.optional(),
+  smufl: z.string().optional(),
+});
+export type AccidentalText = z.infer<typeof AccidentalTextSchema>;
+
+export const NoteheadTextSchema = z.object({
+  displayTexts: z.array(DisplayTextSchema).optional(),
+  accidentalTexts: z.array(AccidentalTextSchema).optional(),
+});
+export type NoteheadText = z.infer<typeof NoteheadTextSchema>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -177,6 +177,11 @@ export type {
 } from "../schemas/notations";
 export type { MidiDevice } from "../schemas/midiDevice";
 export type { TimeModification } from "../schemas/timeModification";
+export type {
+  NoteheadText,
+  DisplayText,
+  AccidentalText,
+} from "../schemas/noteheadText";
 // Add other inferred types from Zod schemas here as they are created.
 
 export type ParsedMusicXml = Record<string, unknown>;

--- a/tests/note.test.ts
+++ b/tests/note.test.ts
@@ -447,5 +447,17 @@ describe("Note Schema Tests (note.mod)", () => {
       expect(note.instrument).toBe("P1-I1");
       expect(note.printObject).toBe("no");
     });
+
+    it("parses notehead-text with display and accidental text", () => {
+      const xml =
+        "<note><pitch><step>C</step><octave>4</octave></pitch><duration>1</duration><notehead-text><display-text>do</display-text><accidental-text>flat</accidental-text></notehead-text></note>";
+      const element = createElement(xml);
+      const note = mapNoteElement(element);
+      expect(note.noteheadText).toBeDefined();
+      expect(note.noteheadText?.length).toBe(1);
+      const nt = note.noteheadText?.[0]!;
+      expect(nt.displayTexts?.[0].text).toBe("do");
+      expect(nt.accidentalTexts?.[0].value).toBe("flat");
+    });
   });
 });


### PR DESCRIPTION
## Summary
- support notehead-text elements
- map notehead-text in parser
- export notehead types
- test notehead-text parsing

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`
