### PR TITLE
Add soft accent articulations support

### DIFF
--- a/src/parser/mappers/noteMappers.ts
+++ b/src/parser/mappers/noteMappers.ts
@@ -55,6 +55,8 @@ import type {
   Mordent, // Add
   Schleifer, // Add
   OtherOrnament, // Add
+  SoftAccent,
+  OtherArticulation,
   Technical,
   Glissando,
   Slide,
@@ -197,6 +199,8 @@ import {
   MordentSchema,
   SchleiferSchema,
   OtherOrnamentSchema,
+  SoftAccentSchema,
+  OtherArticulationSchema,
   FingeringSchema,
   StringSchema,
   FretSchema,
@@ -793,6 +797,12 @@ export const mapArticulationsElement = (element: Element): Articulations => {
   const spiccatoElement = element.querySelector("spiccato");
   const staccatissimoElement = element.querySelector("staccatissimo");
   const strongAccentElement = element.querySelector("strong-accent");
+  const softAccentElements = Array.from(
+    element.querySelectorAll("soft-accent"),
+  );
+  const otherArticulationElements = Array.from(
+    element.querySelectorAll("other-articulation"),
+  );
 
   const articulationsData: Partial<Articulations> = {
     placement: getAttribute(element, "placement") as
@@ -818,6 +828,14 @@ export const mapArticulationsElement = (element: Element): Articulations => {
   }
   if (strongAccentElement) {
     articulationsData.strongAccent = {};
+  }
+  if (softAccentElements.length) {
+    articulationsData.softAccent = softAccentElements.map(mapSoftAccentElement);
+  }
+  if (otherArticulationElements.length) {
+    articulationsData.otherArticulations = otherArticulationElements.map(
+      mapOtherArticulationElement,
+    );
   }
 
   return ArticulationsSchema.parse(articulationsData);
@@ -906,6 +924,22 @@ export const mapOtherOrnamentElement = (el: Element): OtherOrnament => {
     smufl: getAttribute(el, "smufl") || undefined,
   };
   return OtherOrnamentSchema.parse(data);
+};
+
+export const mapSoftAccentElement = (el: Element): SoftAccent => {
+  const data: Partial<SoftAccent> = {
+    placement: getAttribute(el, "placement") as "above" | "below" | undefined,
+  };
+  return SoftAccentSchema.parse(data);
+};
+
+export const mapOtherArticulationElement = (el: Element): OtherArticulation => {
+  const data: Partial<OtherArticulation> = {
+    value: el.textContent?.trim() || undefined,
+    placement: getAttribute(el, "placement") as "above" | "below" | undefined,
+    smufl: getAttribute(el, "smufl") || undefined,
+  };
+  return OtherArticulationSchema.parse(data);
 };
 
 export const mapAccidentalMarkElement = (el: Element): Accidental => {

--- a/src/schemas/notations.ts
+++ b/src/schemas/notations.ts
@@ -175,6 +175,16 @@ export const OtherOrnamentSchema = z.object({
 });
 export type OtherOrnament = z.infer<typeof OtherOrnamentSchema>;
 
+export const SoftAccentSchema = EmptyPlacementSchema;
+export type SoftAccent = z.infer<typeof SoftAccentSchema>;
+
+export const OtherArticulationSchema = z.object({
+  value: z.string().optional(),
+  placement: z.enum(["above", "below"]).optional(),
+  smufl: z.string().optional(),
+});
+export type OtherArticulation = z.infer<typeof OtherArticulationSchema>;
+
 export const OrnamentsSchema = z.object({
   trillMarks: z.array(TrillMarkSchema).optional(),
   turns: z.array(TurnSchema).optional(),
@@ -309,6 +319,8 @@ export const ArticulationsSchema = z.object({
   spiccato: SpiccatoSchema.optional(),
   staccatissimo: StaccatissimoSchema.optional(),
   strongAccent: StrongAccentSchema.optional(),
+  softAccent: z.array(SoftAccentSchema).optional(),
+  otherArticulations: z.array(OtherArticulationSchema).optional(),
   placement: z.enum(["above", "below"]).optional(), // placement for the group
 });
 export type Articulations = z.infer<typeof ArticulationsSchema>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -79,6 +79,8 @@ export type {
   Spiccato,
   Staccatissimo,
   StrongAccent,
+  SoftAccent,
+  OtherArticulation,
   Tuplet,
   Ornaments,
   TrillMark,

--- a/tests/note.test.ts
+++ b/tests/note.test.ts
@@ -238,6 +238,27 @@ describe("Note Schema Tests (note.mod)", () => {
       expect(arts?.placement).toBe("above");
     });
 
+    it("parses <soft-accent> articulation", () => {
+      const xml =
+        '<note><pitch><step>C</step><octave>4</octave></pitch><duration>1</duration><notations><articulations><soft-accent placement="below"/></articulations></notations></note>';
+      const el = createElement(xml);
+      const note = mapNoteElement(el);
+      const art = note.notations?.articulations?.[0];
+      expect(art?.softAccent).toHaveLength(1);
+      expect(art?.softAccent?.[0].placement).toBe("below");
+    });
+
+    it("parses <other-articulation> with smufl attribute", () => {
+      const xml =
+        '<note><pitch><step>C</step><octave>4</octave></pitch><duration>1</duration><notations><articulations><other-articulation smufl="accDoitAbove">doit</other-articulation></articulations></notations></note>';
+      const el = createElement(xml);
+      const note = mapNoteElement(el);
+      const art = note.notations?.articulations?.[0];
+      expect(art?.otherArticulations).toHaveLength(1);
+      expect(art?.otherArticulations?.[0].smufl).toBe("accDoitAbove");
+      expect(art?.otherArticulations?.[0].value).toBe("doit");
+    });
+
     it("maps tied, tuplet, ornaments and technical elements", () => {
       const xml =
         '<note><pitch><step>D</step><octave>4</octave></pitch><duration>2</duration><notations><tied type="start"/><tuplet type="start" number="3"/><ornaments/><technical/></notations></note>';


### PR DESCRIPTION
## Summary
- add `SoftAccentSchema` and `OtherArticulationSchema`
- extend `ArticulationsSchema`
- parse new articulation types in mappers
- test parsing of `<soft-accent>` and `<other-articulation>`

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`