### PR TITLE
Fix formatting schema attribute detection

### DIFF
--- a/src/schemas/credit.ts
+++ b/src/schemas/credit.ts
@@ -1,53 +1,57 @@
 import { z } from "zod";
-import { FontSchema } from "./common"; // Assuming ColorSchema might be added here later
+import { FontStyleEnum, FontWeightEnum } from "./common"; // Assuming ColorSchema might be added here later
 import { LinkSchema } from "./link";
 import { BookmarkSchema } from "./bookmark";
 
 // Placeholder for text formatting attributes (simplified)
-export const TextFormattingSchema = z
-  .object({
-    justify: z.enum(["left", "center", "right"]).optional(),
-    halign: z.enum(["left", "center", "right"]).optional(),
-    valign: z.enum(["top", "middle", "bottom", "baseline"]).optional(),
-    defaultX: z.number().optional(),
-    defaultY: z.number().optional(),
-    relativeX: z.number().optional(),
-    relativeY: z.number().optional(),
-    underline: z.number().optional(),
-    overline: z.number().optional(),
-    lineThrough: z.number().optional(),
-    rotation: z.number().optional(),
-    letterSpacing: z.string().optional(),
-    lineHeight: z.string().optional(),
-    dir: z.enum(["ltr", "rtl", "lro", "rlo"]).optional(),
-    enclosure: z.string().optional(),
-    xmlLang: z.string().optional(),
-    xmlSpace: z.enum(["default", "preserve"]).optional(),
-    color: z.string().optional(),
-  })
-  .merge(FontSchema); // Include font attributes
+export const TextFormattingSchema = z.object({
+  fontFamily: z.string().optional(),
+  fontStyle: FontStyleEnum.optional(),
+  fontSize: z.string().optional(),
+  fontWeight: FontWeightEnum.optional(),
+  justify: z.enum(["left", "center", "right"]).optional(),
+  halign: z.enum(["left", "center", "right"]).optional(),
+  valign: z.enum(["top", "middle", "bottom", "baseline"]).optional(),
+  defaultX: z.number().optional(),
+  defaultY: z.number().optional(),
+  relativeX: z.number().optional(),
+  relativeY: z.number().optional(),
+  underline: z.number().optional(),
+  overline: z.number().optional(),
+  lineThrough: z.number().optional(),
+  rotation: z.number().optional(),
+  letterSpacing: z.string().optional(),
+  lineHeight: z.string().optional(),
+  dir: z.enum(["ltr", "rtl", "lro", "rlo"]).optional(),
+  enclosure: z.string().optional(),
+  xmlLang: z.string().optional(),
+  xmlSpace: z.enum(["default", "preserve"]).optional(),
+  color: z.string().optional(),
+});
 
 // Placeholder for symbol formatting attributes (simplified)
-export const SymbolFormattingSchema = z
-  .object({
-    justify: z.enum(["left", "center", "right"]).optional(),
-    halign: z.enum(["left", "center", "right"]).optional(),
-    valign: z.enum(["top", "middle", "bottom"]).optional(),
-    defaultX: z.number().optional(),
-    defaultY: z.number().optional(),
-    relativeX: z.number().optional(),
-    relativeY: z.number().optional(),
-    underline: z.number().optional(),
-    overline: z.number().optional(),
-    lineThrough: z.number().optional(),
-    rotation: z.number().optional(),
-    letterSpacing: z.string().optional(),
-    lineHeight: z.string().optional(),
-    dir: z.enum(["ltr", "rtl", "lro", "rlo"]).optional(),
-    enclosure: z.string().optional(),
-    color: z.string().optional(),
-  })
-  .merge(FontSchema);
+export const SymbolFormattingSchema = z.object({
+  fontFamily: z.string().optional(),
+  fontStyle: FontStyleEnum.optional(),
+  fontSize: z.string().optional(),
+  fontWeight: FontWeightEnum.optional(),
+  justify: z.enum(["left", "center", "right"]).optional(),
+  halign: z.enum(["left", "center", "right"]).optional(),
+  valign: z.enum(["top", "middle", "bottom"]).optional(),
+  defaultX: z.number().optional(),
+  defaultY: z.number().optional(),
+  relativeX: z.number().optional(),
+  relativeY: z.number().optional(),
+  underline: z.number().optional(),
+  overline: z.number().optional(),
+  lineThrough: z.number().optional(),
+  rotation: z.number().optional(),
+  letterSpacing: z.string().optional(),
+  lineHeight: z.string().optional(),
+  dir: z.enum(["ltr", "rtl", "lro", "rlo"]).optional(),
+  enclosure: z.string().optional(),
+  color: z.string().optional(),
+});
 
 export const CreditTypeSchema = z.string();
 

--- a/src/schemas/defaults.ts
+++ b/src/schemas/defaults.ts
@@ -1,5 +1,10 @@
 import { z } from "zod";
-import { FontSchema, MarginsSchema, LineWidthSchema } from "./common";
+import {
+  FontStyleEnum,
+  FontWeightEnum,
+  MarginsSchema,
+  LineWidthSchema,
+} from "./common";
 
 /**
  * Defines the scaling from global tenths to physical units.
@@ -68,10 +73,15 @@ export const AppearanceSchema = z.object({
 
 export const ConcertScoreSchema = z.object({}); // Empty element
 
-export const MusicFontSchema = FontSchema;
-export const WordFontSchema = FontSchema;
+export const MusicFontSchema = z.object({
+  fontFamily: z.string().optional(),
+  fontStyle: FontStyleEnum.optional(),
+  fontSize: z.string().optional(),
+  fontWeight: FontWeightEnum.optional(),
+});
+export const WordFontSchema = MusicFontSchema;
 
-export const LyricFontSchema = FontSchema.extend({
+export const LyricFontSchema = MusicFontSchema.extend({
   number: z.string().optional(), // NMTOKEN
   name: z.string().optional(), // CDATA
 });

--- a/src/schemas/lyric.ts
+++ b/src/schemas/lyric.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { FontSchema } from "./common";
+import { FontStyleEnum, FontWeightEnum } from "./common";
 
 export const ExtendSchema = z.object({
   type: z.enum(["start", "stop", "continue"]).optional(),
@@ -11,7 +11,11 @@ export const ElisionSchema = z.object({
 });
 export type Elision = z.infer<typeof ElisionSchema>;
 
-export const LyricFormattingSchema = FontSchema.extend({
+export const LyricFormattingSchema = z.object({
+  fontFamily: z.string().optional(),
+  fontStyle: FontStyleEnum.optional(),
+  fontSize: z.string().optional(),
+  fontWeight: FontWeightEnum.optional(),
   justify: z.enum(["left", "center", "right"]).optional(),
   underline: z.number().optional(),
   overline: z.number().optional(),

--- a/tests/credit.test.ts
+++ b/tests/credit.test.ts
@@ -93,4 +93,13 @@ describe("Credit parsing", () => {
     expect(w2.text).toBe("World");
     expect(w2.formatting?.overline).toBe(1);
   });
+
+  it("parses letter-spacing and line-height", () => {
+    const xml = `<credit><credit-words letter-spacing="0.5em" line-height="1.5">Hi</credit-words></credit>`;
+    const element = createElement(xml);
+    const credit = mapCreditElement(element)!;
+    const word = credit.items?.[0] as any;
+    expect(word.formatting?.letterSpacing).toBe("0.5em");
+    expect(word.formatting?.lineHeight).toBe("1.5");
+  });
 });


### PR DESCRIPTION
## Summary
- inline font attributes for text-related schemas so xsd consistency check can find them
- update defaults font schemas accordingly
- add a test for credit letter-spacing and line-height

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`
- `npx vitest run tests/xsdAttributesConsistency.test.ts`