### PR TITLE
Add instrument-change mapping

### DIFF
--- a/src/parser/mappers/measureMappers.ts
+++ b/src/parser/mappers/measureMappers.ts
@@ -110,6 +110,7 @@ import type {
   MidiDevice,
   FiguredBass,
   Figure,
+  InstrumentChange,
   Grouping,
   Feature,
   Link,
@@ -255,6 +256,7 @@ import {
   FirstFretSchema,
   MidiDeviceSchema,
   MidiInstrumentSchema,
+  InstrumentChangeSchema,
 } from "../../schemas";
 import {
   mapDefaultsElement,
@@ -1003,6 +1005,15 @@ export function mapSoundElement(element: Element): Sound {
   }
   if (idAttr) soundData.id = idAttr;
 
+  const instChangeElements = Array.from(
+    element.querySelectorAll("instrument-change"),
+  );
+  if (instChangeElements.length > 0) {
+    soundData.instrumentChanges = instChangeElements.map(
+      mapInstrumentChangeElement,
+    );
+  }
+
   return SoundSchema.parse(soundData);
 }
 
@@ -1385,6 +1396,31 @@ export const mapMidiInstrumentElement = (element: Element): MidiInstrument => {
     elevation: parseFloatContent(element, "elevation"),
   };
   return MidiInstrumentSchema.parse(data);
+};
+
+export const mapInstrumentChangeElement = (
+  element: Element,
+): InstrumentChange => {
+  const data: Partial<InstrumentChange> = {
+    _type: "instrument-change",
+    id: getAttribute(element, "id") ?? "",
+  };
+  const sound = getTextContent(element, "instrument-sound");
+  if (sound) data.instrumentSound = sound;
+  if (element.querySelector("solo")) data.solo = true;
+  const ensembleEl = element.querySelector("ensemble");
+  if (ensembleEl) {
+    const size = parseInt(ensembleEl.textContent ?? "", 10);
+    if (!isNaN(size)) data.ensemble = size;
+  }
+  const virt = element.querySelector("virtual-instrument");
+  if (virt) {
+    const lib = getTextContent(virt, "virtual-library");
+    if (lib) data.virtualLibrary = lib;
+    const name = getTextContent(virt, "virtual-name");
+    if (name) data.virtualName = name;
+  }
+  return InstrumentChangeSchema.parse(data);
 };
 
 // Mapper for <score-part> element (from <part-list>)

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -31,6 +31,7 @@ export * from "./beam";
 export * from "./partSymbol";
 export * from "./partGroup";
 export * from "./scoreInstrument";
+export * from "./instrumentChange";
 export * from "./midiInstrument";
 export * from "./grace";
 export * from "./cue";

--- a/src/schemas/instrumentChange.ts
+++ b/src/schemas/instrumentChange.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const InstrumentChangeSchema = z.object({
+  _type: z.literal("instrument-change"),
+  id: z.string(),
+  instrumentSound: z.string().optional(),
+  solo: z.boolean().optional(),
+  ensemble: z.number().int().optional(),
+  virtualLibrary: z.string().optional(),
+  virtualName: z.string().optional(),
+});
+
+export type InstrumentChange = z.infer<typeof InstrumentChangeSchema>;

--- a/src/schemas/sound.ts
+++ b/src/schemas/sound.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { YesNoEnum, YesNoNumberSchema, RotationDegreesSchema } from "./common";
+import { InstrumentChangeSchema } from "./instrumentChange";
 
 export const SoundSchema = z.object({
   _type: z.literal("sound"),
@@ -21,6 +22,7 @@ export const SoundSchema = z.object({
   softPedal: YesNoNumberSchema.optional(),
   sostenutoPedal: YesNoNumberSchema.optional(),
   id: z.string().optional(),
+  instrumentChanges: z.array(InstrumentChangeSchema).optional(),
 });
 
 export type Sound = z.infer<typeof SoundSchema>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -164,6 +164,7 @@ export type { Footnote, Level } from "../schemas/editorial";
 export type { GroupSymbolValue } from "../schemas/partSymbol";
 export type { PartGroup } from "../schemas/partGroup";
 export type { ScoreInstrument } from "../schemas/scoreInstrument";
+export type { InstrumentChange } from "../schemas/instrumentChange";
 export type { MidiInstrument } from "../schemas/midiInstrument";
 export type { FiguredBass, Figure } from "../schemas/figuredBass";
 export type { Grouping, Feature } from "../schemas/grouping";

--- a/tests/instrumentChange.test.ts
+++ b/tests/instrumentChange.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { JSDOM } from "jsdom";
+import { mapSoundElement } from "../src/parser/mappers";
+
+function createElement(xmlString: string): Element {
+  const dom = new JSDOM(xmlString, { contentType: "application/xml" });
+  const err = dom.window.document.querySelector("parsererror");
+  if (err) throw new Error("Invalid XML");
+  return dom.window.document.documentElement;
+}
+
+describe("Instrument-change parsing", () => {
+  it("parses instrument-change within sound", () => {
+    const xml = `<sound><instrument-change id="P1-I1"><instrument-sound>piano</instrument-sound><solo/></instrument-change></sound>`;
+    const el = createElement(xml);
+    const sound = mapSoundElement(el);
+    expect(sound.instrumentChanges?.length).toBe(1);
+    const change = sound.instrumentChanges?.[0];
+    expect(change?.id).toBe("P1-I1");
+    expect(change?.instrumentSound).toBe("piano");
+    expect(change?.solo).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- support `<instrument-change>` elements inside `<sound>`
- expose new `InstrumentChange` type
- test instrument-change parsing

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`
