### PR TITLE
Handle container.xml in .mxl archives

### DIFF
--- a/tests/readMusicXmlFile.test.ts
+++ b/tests/readMusicXmlFile.test.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 import { readMusicXmlFile } from "../src/utils/readMusicXmlFile";
 
 const samplesDir = path.resolve(__dirname, "../reference/xmlsamples");
+const dataDir = path.resolve(__dirname, "./data");
 
 describe("readMusicXmlFile", () => {
   it("extracts MusicXML from MXL archives", async () => {
@@ -13,5 +14,12 @@ describe("readMusicXmlFile", () => {
       path.join(samplesDir, "ActorPreludeSample.musicxml"),
     );
     expect(fromArchive).toBe(direct);
+  });
+
+  it("uses container manifest to locate the score", async () => {
+    const xml = await readMusicXmlFile(path.join(dataDir, "container.mxl"));
+    const expected =
+      '<score-partwise version="3.1"><part-list></part-list><part id="P1"><measure number="1"></measure></part></score-partwise>\n';
+    expect(xml).toBe(expected);
   });
 });


### PR DESCRIPTION
## Summary
- use META-INF/container.xml to locate the main score in MXL files
- add regression test for container manifest

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`
