### PR TITLE
Extend rest parsing

### DIFF
--- a/src/parser/mappers/noteMappers.ts
+++ b/src/parser/mappers/noteMappers.ts
@@ -88,6 +88,7 @@ import type {
   Grace,
   Cue,
   Unpitched,
+  Rest,
   TimeModification,
   Font,
   Scaling,
@@ -241,6 +242,7 @@ import {
   GraceSchema,
   CueSchema,
   UnpitchedSchema,
+  RestSchema,
   TimeModificationSchema,
   FontSchema,
   ScalingSchema,
@@ -613,9 +615,14 @@ export const mapNoteElement = (element: Element): Note => {
   } else if (unpitchedElement) {
     noteData.unpitched = mapUnpitchedElement(unpitchedElement);
   } else if (restElement) {
-    noteData.rest = {
-      // measure: getAttribute(restElement, 'measure') === 'yes' ? true : undefined,
+    const measureAttr = getAttribute(restElement, "measure");
+    const restData: Partial<Rest> = {
+      measure:
+        measureAttr === "yes" ? true : measureAttr === "no" ? false : undefined,
+      displayStep: getTextContent(restElement, "display-step"),
+      displayOctave: parseNumberContent(restElement, "display-octave"),
     };
+    noteData.rest = RestSchema.parse(restData);
   }
 
   // Duration is handled based on grace/cue presence by NoteSchema.refine

--- a/src/schemas/rest.ts
+++ b/src/schemas/rest.ts
@@ -11,10 +11,9 @@ export const RestSchema = z.object({
    * refers to a full measure rest. It is not typically used for <note> rests.
    * For now, we'll keep it simple and can extend later if needed for <forward>/<backup>.
    */
-  // measure: z.boolean().optional(), // Example: if it were a boolean attribute 'measure="yes"'
-  /** Specifies the visual placement of the rest. Not parsed for now. */
-  // 'display-step': z.string().optional(),
-  // 'display-octave': z.number().int().optional(),
+  measure: z.boolean().optional(),
+  displayStep: z.string().optional(),
+  displayOctave: z.number().int().optional(),
 });
 
 export type Rest = z.infer<typeof RestSchema>;

--- a/tests/note.test.ts
+++ b/tests/note.test.ts
@@ -56,6 +56,22 @@ describe("Note Schema Tests (note.mod)", () => {
       expect(note.type).toBe("quarter");
     });
 
+    it("parses rest display information", () => {
+      const xml =
+        "<note><rest><display-step>B</display-step><display-octave>4</display-octave></rest><duration>4</duration></note>";
+      const element = createElement(xml);
+      const note = mapNoteElement(element);
+      expect(note.rest?.displayStep).toBe("B");
+      expect(note.rest?.displayOctave).toBe(4);
+    });
+
+    it("parses whole-measure rest", () => {
+      const xml = '<note><rest measure="yes"/><duration>4</duration></note>';
+      const element = createElement(xml);
+      const note = mapNoteElement(element);
+      expect(note.rest?.measure).toBe(true);
+    });
+
     it("should parse a <note> with <chord>", () => {
       const xml =
         "<note><chord/><pitch><step>E</step><octave>4</octave></pitch><duration>2</duration></note>";


### PR DESCRIPTION
## Summary
- support measure, display-step and display-octave on rests
- parse new rest fields in note mapper
- test rest attributes including whole-measure rests

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`