### PR TITLE
Capture metronome parentheses attribute

### DIFF
--- a/src/parser/mappers/noteMappers.ts
+++ b/src/parser/mappers/noteMappers.ts
@@ -1779,6 +1779,10 @@ export const mapMetronomeElement = (element: Element): Metronome => {
     element.querySelectorAll("metronome-note"),
   );
   const relationElement = element.querySelector("metronome-relation");
+  const parenthesesAttr = getAttribute(element, "parentheses") as
+    | "yes"
+    | "no"
+    | undefined;
   const metronomeData: Partial<Metronome> = {};
   if (beatUnitElement) {
     metronomeData["beat-unit"] = mapMetronomeBeatUnitElement(beatUnitElement);
@@ -1795,6 +1799,9 @@ export const mapMetronomeElement = (element: Element): Metronome => {
   if (relationElement) {
     metronomeData["metronome-relation"] =
       relationElement.textContent?.trim() ?? "";
+  }
+  if (parenthesesAttr) {
+    metronomeData.parentheses = parenthesesAttr;
   }
   return MetronomeSchema.parse(metronomeData);
 };

--- a/src/schemas/direction.ts
+++ b/src/schemas/direction.ts
@@ -50,7 +50,7 @@ export const MetronomeSchema = z.object({
   "per-minute": MetronomePerMinuteSchema.optional(),
   "metronome-note": z.array(MetronomeNoteSchema).optional(),
   "metronome-relation": z.string().optional(),
-  // parentheses: z.boolean().optional(), // Example attribute
+  parentheses: YesNoEnum.optional(),
 });
 export type Metronome = z.infer<typeof MetronomeSchema>;
 

--- a/tests/direction.test.ts
+++ b/tests/direction.test.ts
@@ -80,6 +80,14 @@ describe("Direction parsing", () => {
     expect(met["metronome-note"]?.[1]["metronome-type"]).toBe("eighth");
   });
 
+  it("parses metronome parentheses attribute", () => {
+    const xml = `<direction><direction-type><metronome parentheses="yes"><beat-unit>quarter</beat-unit><per-minute>120</per-minute></metronome></direction-type></direction>`;
+    const el = createElement(xml);
+    const direction = mapDirectionElement(el);
+    const met = direction.direction_type[0].metronome!;
+    expect(met.parentheses).toBe("yes");
+  });
+
   it("parses directive attribute", () => {
     const xml = `<direction directive="yes"><direction-type><words>Tempo</words></direction-type></direction>`;
     const el = createElement(xml);


### PR DESCRIPTION
## Summary
- allow `MetronomeSchema` to store an optional `parentheses` attribute
- read the `parentheses` attribute in `mapMetronomeElement`
- test metronome parentheses parsing

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`