### PR TITLE
Add segno/coda placement parsing

### DIFF
--- a/src/parser/mappers/noteMappers.ts
+++ b/src/parser/mappers/noteMappers.ts
@@ -22,8 +22,8 @@ import type {
   MetronomeRelation,
   // Dynamics,
   Wedge,
-  // Segno,
-  //Coda,
+  Segno,
+  Coda,
   Transpose,
   // Diatonic,
   // Chromatic,
@@ -1712,6 +1712,62 @@ export const mapOtherDirectionElement = (element: Element): OtherDirection => {
   return OtherDirectionSchema.parse({ text });
 };
 
+export const mapSegnoElement = (element: Element): Segno => {
+  const data: Partial<Segno> = {};
+  const dxAttr = getAttribute(element, "default-x");
+  if (dxAttr) {
+    const val = parseOptionalFloat(dxAttr);
+    if (val !== undefined) data.defaultX = val;
+  }
+  const dyAttr = getAttribute(element, "default-y");
+  if (dyAttr) {
+    const val = parseOptionalFloat(dyAttr);
+    if (val !== undefined) data.defaultY = val;
+  }
+  const rxAttr = getAttribute(element, "relative-x");
+  if (rxAttr) {
+    const val = parseOptionalFloat(rxAttr);
+    if (val !== undefined) data.relativeX = val;
+  }
+  const ryAttr = getAttribute(element, "relative-y");
+  if (ryAttr) {
+    const val = parseOptionalFloat(ryAttr);
+    if (val !== undefined) data.relativeY = val;
+  }
+  const placementAttr = getAttribute(element, "placement");
+  if (placementAttr === "above" || placementAttr === "below")
+    data.placement = placementAttr as "above" | "below";
+  return SegnoSchema.parse(data);
+};
+
+export const mapCodaElement = (element: Element): Coda => {
+  const data: Partial<Coda> = {};
+  const dxAttr = getAttribute(element, "default-x");
+  if (dxAttr) {
+    const val = parseOptionalFloat(dxAttr);
+    if (val !== undefined) data.defaultX = val;
+  }
+  const dyAttr = getAttribute(element, "default-y");
+  if (dyAttr) {
+    const val = parseOptionalFloat(dyAttr);
+    if (val !== undefined) data.defaultY = val;
+  }
+  const rxAttr = getAttribute(element, "relative-x");
+  if (rxAttr) {
+    const val = parseOptionalFloat(rxAttr);
+    if (val !== undefined) data.relativeX = val;
+  }
+  const ryAttr = getAttribute(element, "relative-y");
+  if (ryAttr) {
+    const val = parseOptionalFloat(ryAttr);
+    if (val !== undefined) data.relativeY = val;
+  }
+  const placementAttr = getAttribute(element, "placement");
+  if (placementAttr === "above" || placementAttr === "below")
+    data.placement = placementAttr as "above" | "below";
+  return CodaSchema.parse(data);
+};
+
 // Helper function to map a <beat-unit> element (within <metronome>)
 export const mapMetronomeBeatUnitElement = (
   element: Element,
@@ -1968,10 +2024,10 @@ export const mapDirectionTypeElement = (element: Element): DirectionType => {
     if (img) directionTypeData.image = img;
   }
   if (segnoElement) {
-    directionTypeData.segno = SegnoSchema.parse({});
+    directionTypeData.segno = mapSegnoElement(segnoElement);
   }
   if (codaElement) {
-    directionTypeData.coda = CodaSchema.parse({});
+    directionTypeData.coda = mapCodaElement(codaElement);
   }
   return DirectionTypeSchema.parse(directionTypeData);
 };

--- a/src/schemas/direction.ts
+++ b/src/schemas/direction.ts
@@ -85,10 +85,22 @@ export const WedgeSchema = z.object({
 });
 export type Wedge = z.infer<typeof WedgeSchema>;
 
-export const SegnoSchema = z.object({});
+export const SegnoSchema = z.object({
+  defaultX: z.number().optional(),
+  defaultY: z.number().optional(),
+  relativeX: z.number().optional(),
+  relativeY: z.number().optional(),
+  placement: z.enum(["above", "below"]).optional(),
+});
 export type Segno = z.infer<typeof SegnoSchema>;
 
-export const CodaSchema = z.object({});
+export const CodaSchema = z.object({
+  defaultX: z.number().optional(),
+  defaultY: z.number().optional(),
+  relativeX: z.number().optional(),
+  relativeY: z.number().optional(),
+  placement: z.enum(["above", "below"]).optional(),
+});
 export type Coda = z.infer<typeof CodaSchema>;
 
 export const OctaveShiftSchema = z.object({

--- a/tests/direction.test.ts
+++ b/tests/direction.test.ts
@@ -192,6 +192,30 @@ describe("Direction parsing", () => {
     expect(sc.accord[0].string).toBe("1");
   });
 
+  it("parses segno attributes", () => {
+    const xml = `<direction><direction-type><segno default-x="3.5" default-y="-2" relative-x="1" relative-y="2" placement="below"/></direction-type></direction>`;
+    const el = createElement(xml);
+    const direction = mapDirectionElement(el);
+    const seg = direction.direction_type[0].segno!;
+    expect(seg.defaultX).toBe(3.5);
+    expect(seg.defaultY).toBe(-2);
+    expect(seg.relativeX).toBe(1);
+    expect(seg.relativeY).toBe(2);
+    expect(seg.placement).toBe("below");
+  });
+
+  it("parses coda attributes", () => {
+    const xml = `<direction><direction-type><coda default-x="1" default-y="2" relative-x="-1" relative-y="-2" placement="above"/></direction-type></direction>`;
+    const el = createElement(xml);
+    const direction = mapDirectionElement(el);
+    const coda = direction.direction_type[0].coda!;
+    expect(coda.defaultX).toBe(1);
+    expect(coda.defaultY).toBe(2);
+    expect(coda.relativeX).toBe(-1);
+    expect(coda.relativeY).toBe(-2);
+    expect(coda.placement).toBe("above");
+  });
+
   it("parses other-direction element", () => {
     const xml = `<direction><direction-type><other-direction>custom</other-direction></direction-type></direction>`;
     const el = createElement(xml);


### PR DESCRIPTION
## Summary
- support placement/position attributes for segno and coda
- parse segno and coda attributes in direction mapper
- test segno and coda attribute parsing

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`
