### PR TITLE
Add standard instrument mapping

### DIFF
--- a/src/parser/mappers/measureMappers.ts
+++ b/src/parser/mappers/measureMappers.ts
@@ -286,6 +286,7 @@ import {
   parseOptionalInt,
   parseOptionalFloat,
 } from "./utils";
+import { mapToStandardInstrumentId } from "../../utils/instrumentMapping";
 import {
   mapNoteElement,
   mapKeyElement,
@@ -1368,6 +1369,11 @@ export const mapScoreInstrumentElement = (
   if (abbr) data.instrumentAbbreviation = abbr;
   const sound = getTextContent(element, "instrument-sound");
   if (sound) data.instrumentSound = sound;
+  const standardId = mapToStandardInstrumentId(
+    data.instrumentName,
+    sound ?? undefined,
+  );
+  if (standardId) data.standardId = standardId;
   if (element.querySelector("solo")) data.solo = true;
   const ensemble = element.querySelector("ensemble");
   if (ensemble) {

--- a/src/schemas/scoreInstrument.ts
+++ b/src/schemas/scoreInstrument.ts
@@ -24,6 +24,8 @@ export const ScoreInstrumentSchema = z
     virtualName: z.string().optional(),
     /** Initial MIDI instrument assignment */
     midiInstrument: MidiInstrumentSchema.optional(),
+    /** Mapped standard instrument identifier */
+    standardId: z.string().optional(),
   })
   .passthrough();
 

--- a/src/utils/instrumentMapping.ts
+++ b/src/utils/instrumentMapping.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from "fs";
+import { JSDOM } from "jsdom";
+import { join } from "path";
+
+let soundIds: string[] | null = null;
+
+function loadSoundIds(): string[] {
+  if (soundIds) return soundIds;
+  try {
+    const filePath = join(
+      __dirname,
+      "../../reference/musicxml-4.0/schema/sounds.xml",
+    );
+    const xml = readFileSync(filePath, "utf8");
+    const dom = new JSDOM(xml, { contentType: "application/xml" });
+    soundIds = Array.from(dom.window.document.getElementsByTagName("sound"))
+      .map((el) => el.getAttribute("id") || "")
+      .filter((id) => id !== "");
+  } catch {
+    soundIds = [];
+  }
+  return soundIds;
+}
+
+const NAME_TO_ID: Record<string, string> = {
+  piano: "keyboard.piano",
+  violin: "strings.violin",
+  flute: "wind.flute",
+  clarinet: "wind.clarinet",
+  trumpet: "brass.trumpet",
+  cello: "strings.cello",
+};
+
+export function mapToStandardInstrumentId(
+  name?: string,
+  sound?: string,
+): string | undefined {
+  const ids = loadSoundIds();
+  if (sound && ids.includes(sound)) return sound;
+  if (!name) return undefined;
+
+  const byName = NAME_TO_ID[name.toLowerCase()];
+  if (byName && ids.includes(byName)) return byName;
+
+  const slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+
+  for (const id of ids) {
+    if (
+      id === slug ||
+      id.endsWith(slug) ||
+      id.includes(slug.replace(/-/g, "."))
+    ) {
+      return id;
+    }
+    const idSlug = id.replace(/[.]/g, "-");
+    if (idSlug === slug || idSlug.endsWith(slug)) return id;
+  }
+  return undefined;
+}

--- a/tests/instrumentMapping.test.ts
+++ b/tests/instrumentMapping.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { parseMusicXmlString } from "../src/parser/xmlParser";
+import { mapDocumentToScorePartwise } from "../src/parser/mappers";
+
+const xmlViolin = `
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1">
+      <part-name>Violin</part-name>
+      <score-instrument id="P1-I1">
+        <instrument-name>Violin</instrument-name>
+      </score-instrument>
+    </score-part>
+  </part-list>
+  <part id="P1"><measure number="1"/></part>
+</score-partwise>`;
+
+describe("Standard instrument mapping", () => {
+  it("maps by instrument-sound when provided", async () => {
+    const xml = `
+    <score-partwise version="3.1">
+      <part-list>
+        <score-part id="P1">
+          <part-name>Piano</part-name>
+          <score-instrument id="P1-I1">
+            <instrument-name>Piano</instrument-name>
+            <instrument-sound>keyboard.piano</instrument-sound>
+          </score-instrument>
+        </score-part>
+      </part-list>
+      <part id="P1"><measure number="1"/></part>
+    </score-partwise>`;
+    const doc = await parseMusicXmlString(xml);
+    expect(doc).not.toBeNull();
+    if (!doc) return;
+    const score = mapDocumentToScorePartwise(doc);
+    const instr = score.partList.scoreParts[0].scoreInstruments?.[0];
+    expect(instr?.standardId).toBe("keyboard.piano");
+  });
+
+  it("maps by instrument name when sound missing", async () => {
+    const doc = await parseMusicXmlString(xmlViolin);
+    expect(doc).not.toBeNull();
+    if (!doc) return;
+    const score = mapDocumentToScorePartwise(doc);
+    const instr = score.partList.scoreParts[0].scoreInstruments?.[0];
+    expect(instr?.standardId).toBe("strings.violin");
+  });
+});

--- a/tests/scorePartMidi.test.ts
+++ b/tests/scorePartMidi.test.ts
@@ -37,6 +37,7 @@ describe("Score-part MIDI parsing", () => {
     const instr = part.scoreInstruments?.[0];
     expect(instr?.instrumentName).toBe("Piano");
     expect(instr?.instrumentSound).toBe("keyboard.piano");
+    expect(instr?.standardId).toBe("keyboard.piano");
     expect(part.midiDevices?.[0].value).toBe("Device");
     expect(part.midiDevices?.[0].port).toBe(1);
     expect(part.midiInstruments?.[0].midiChannel).toBe(1);


### PR DESCRIPTION
## Summary
- track standard instrument identifier in `ScoreInstrument`
- add mapping logic that looks up `sounds.xml`
- extend parser to attach `standardId`
- test mapping for instrument names and sounds

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`
