### PR TITLE
Add instrument sound mapping

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,4 @@ export * from "./types"; // Zodから推論される型などをエクスポー�
 export * from "./converters";
 export { toMusicXML } from "./converters";
 export * from "./utils/readMusicXmlFile";
+export * from "./utils/loadSoundsXml";

--- a/src/parser/mappers/measureMappers.ts
+++ b/src/parser/mappers/measureMappers.ts
@@ -286,6 +286,7 @@ import {
   parseOptionalInt,
   parseOptionalFloat,
 } from "./utils";
+import { getStandardInstrumentId } from "../../utils/loadSoundsXml";
 import {
   mapNoteElement,
   mapKeyElement,
@@ -1360,14 +1361,20 @@ export const mapTimewiseMeasureElement = (
 export const mapScoreInstrumentElement = (
   element: Element,
 ): ScoreInstrument => {
+  const instrumentName = getTextContent(element, "instrument-name") ?? "";
   const data: Partial<ScoreInstrument> = {
     id: getAttribute(element, "id") ?? "",
-    instrumentName: getTextContent(element, "instrument-name") ?? "",
+    instrumentName,
   };
   const abbr = getTextContent(element, "instrument-abbreviation");
   if (abbr) data.instrumentAbbreviation = abbr;
   const sound = getTextContent(element, "instrument-sound");
   if (sound) data.instrumentSound = sound;
+  let stdId = sound ? getStandardInstrumentId(sound) : undefined;
+  if (!stdId && instrumentName) {
+    stdId = getStandardInstrumentId(instrumentName);
+  }
+  if (stdId) data.standardInstrumentId = stdId;
   if (element.querySelector("solo")) data.solo = true;
   const ensemble = element.querySelector("ensemble");
   if (ensemble) {

--- a/src/schemas/scoreInstrument.ts
+++ b/src/schemas/scoreInstrument.ts
@@ -15,6 +15,8 @@ export const ScoreInstrumentSchema = z
     instrumentAbbreviation: z.string().optional(),
     /** Default timbre or sound description */
     instrumentSound: z.string().optional(),
+    /** Standard instrument sound identifier from sounds.xml */
+    standardInstrumentId: z.string().optional(),
     /** True if performance is intended as solo */
     solo: z.boolean().optional(),
     /** Size of an ensemble if specified */

--- a/src/utils/loadSoundsXml.ts
+++ b/src/utils/loadSoundsXml.ts
@@ -1,0 +1,39 @@
+import { promises as fs } from "fs";
+import { parseMusicXmlStringSync } from "../parser/xmlParser";
+
+let soundsMap: Map<string, string> | undefined;
+
+export async function loadSoundsXml(
+  filePath: string,
+): Promise<Map<string, string>> {
+  const xml = await fs.readFile(filePath, "utf8");
+  const doc = parseMusicXmlStringSync(xml);
+  if (!doc) throw new Error("Failed to parse sounds.xml");
+  const map = new Map<string, string>();
+  const soundElements = Array.from(doc.getElementsByTagName("sound"));
+  for (const el of soundElements) {
+    const id = el.getAttribute("id");
+    if (!id) continue;
+    map.set(id.toLowerCase(), id);
+    const text =
+      el.childNodes.length === 1 ? el.textContent?.trim() : undefined;
+    if (text) map.set(text.toLowerCase(), id);
+    const sub = el.querySelectorAll("any,solo,ensemble");
+    sub.forEach((child) => {
+      const t = child.textContent?.trim();
+      if (t) map.set(t.toLowerCase(), id);
+    });
+  }
+  soundsMap = map;
+  return map;
+}
+
+export function getStandardInstrumentId(
+  nameOrSound: string,
+): string | undefined {
+  return soundsMap?.get(nameOrSound.toLowerCase());
+}
+
+export function getStandardInstrumentMap(): Map<string, string> | undefined {
+  return soundsMap;
+}

--- a/tests/loadSoundsXml.test.ts
+++ b/tests/loadSoundsXml.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import path from "path";
+import {
+  loadSoundsXml,
+  getStandardInstrumentId,
+  getStandardInstrumentMap,
+} from "../src/utils/loadSoundsXml";
+
+const samplePath = path.join(__dirname, "sounds-sample.xml");
+
+describe("loadSoundsXml", () => {
+  beforeEach(async () => {
+    await loadSoundsXml(samplePath);
+  });
+
+  it("creates a mapping from names to ids", () => {
+    const map = getStandardInstrumentMap();
+    expect(map).toBeDefined();
+    expect(map?.get("piano")).toBe("keyboard.piano");
+    expect(getStandardInstrumentId("Trumpet")).toBe("brass.trumpet");
+    expect(getStandardInstrumentId("Violin Solo")).toBe("strings.violin");
+  });
+});

--- a/tests/scoreInstrumentMapping.test.ts
+++ b/tests/scoreInstrumentMapping.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { parseMusicXmlString } from "../src/parser/xmlParser";
+import { mapDocumentToScorePartwise } from "../src/parser/mappers";
+import path from "path";
+import { loadSoundsXml } from "../src/utils/loadSoundsXml";
+
+const soundsPath = path.join(__dirname, "sounds-sample.xml");
+
+const xmlName = `
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      <score-instrument id="P1-I1">
+        <instrument-name>Piano</instrument-name>
+      </score-instrument>
+    </score-part>
+  </part-list>
+  <part id="P1"><measure number="1"/></part>
+</score-partwise>`;
+
+const xmlSound = `
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1">
+      <part-name>Trumpet</part-name>
+      <score-instrument id="P1-I1">
+        <instrument-sound>brass.trumpet</instrument-sound>
+      </score-instrument>
+    </score-part>
+  </part-list>
+  <part id="P1"><measure number="1"/></part>
+</score-partwise>`;
+
+describe("score-instrument mapping", () => {
+  it("maps standard id from instrument name", async () => {
+    await loadSoundsXml(soundsPath);
+    const doc = await parseMusicXmlString(xmlName);
+    const score = mapDocumentToScorePartwise(doc!);
+    const instr = score.partList.scoreParts[0].scoreInstruments?.[0];
+    expect(instr?.standardInstrumentId).toBe("keyboard.piano");
+  });
+
+  it("maps standard id from instrument sound", async () => {
+    await loadSoundsXml(soundsPath);
+    const doc = await parseMusicXmlString(xmlSound);
+    const score = mapDocumentToScorePartwise(doc!);
+    const instr = score.partList.scoreParts[0].scoreInstruments?.[0];
+    expect(instr?.standardInstrumentId).toBe("brass.trumpet");
+  });
+});

--- a/tests/sounds-sample.xml
+++ b/tests/sounds-sample.xml
@@ -1,0 +1,10 @@
+<sounds>
+  <sound id="keyboard.piano">Piano</sound>
+  <sound id="brass.trumpet">
+    <any>Trumpet</any>
+  </sound>
+  <sound id="strings.violin">
+    <solo>Violin Solo</solo>
+    <ensemble>Violin Ensemble</ensemble>
+  </sound>
+</sounds>


### PR DESCRIPTION
## Summary
- implement `loadSoundsXml` utility to load `sounds.xml`
- expose the loader through the library entrypoint
- extend `ScoreInstrument` schema with `standardInstrumentId`
- map score-instrument names or sounds to standard IDs
- test sound mapping with a sample `sounds.xml`

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`