### PR TITLE
Add basic opus root parsing

### DIFF
--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1,24 +1,28 @@
 export * from "./xmlParser";
 export * from "./mappers";
 
-import type { ScorePartwise } from "../types";
+import type { ScorePartwise, ScoreTimewise, OpusDocument } from "../types";
 import { parseMusicXmlString, parseMusicXmlStringSync } from "./xmlParser";
-import { mapDocumentToScorePartwise } from "./mappers";
+import { mapDocument, mapDocumentSync } from "./mappers";
 
 /**
  * Parse a MusicXML string and map it directly to {@link ScorePartwise}.
  */
 export async function parseMusicXml(
   xml: string,
-): Promise<ScorePartwise | null> {
+  options: { basePath?: string } = {},
+): Promise<ScorePartwise | ScoreTimewise | OpusDocument | null> {
   const doc = await parseMusicXmlString(xml);
-  return doc ? mapDocumentToScorePartwise(doc) : null;
+  return doc ? mapDocument(doc, options) : null;
 }
 
 /**
  * Synchronous version of {@link parseMusicXml}.
  */
-export function parseMusicXmlSync(xml: string): ScorePartwise | null {
+export function parseMusicXmlSync(
+  xml: string,
+  options: { basePath?: string } = {},
+): ScorePartwise | ScoreTimewise | OpusDocument | null {
   const doc = parseMusicXmlStringSync(xml);
-  return doc ? mapDocumentToScorePartwise(doc) : null;
+  return doc ? mapDocumentSync(doc, options) : null;
 }

--- a/src/parser/mappers/index.ts
+++ b/src/parser/mappers/index.ts
@@ -2,3 +2,4 @@ export * from "./noteMappers";
 export * from "./measureMappers";
 export * from "./creditMappers";
 export * from "./defaultsMappers";
+export * from "./opusMapper";

--- a/src/parser/mappers/opusMapper.ts
+++ b/src/parser/mappers/opusMapper.ts
@@ -1,0 +1,105 @@
+import * as fsp from "fs/promises";
+import * as fs from "fs";
+import * as path from "path";
+import { parseMusicXmlString, parseMusicXmlStringSync } from "../xmlParser";
+import {
+  mapDocumentToScorePartwise,
+  mapDocumentToScoreTimewise,
+} from "./measureMappers";
+import type { OpusDocument, ScorePartwise, ScoreTimewise } from "../../types";
+
+interface MapOptions {
+  basePath?: string;
+}
+
+async function parseLinkedFile(
+  href: string,
+  options: MapOptions,
+): Promise<ScorePartwise | ScoreTimewise | OpusDocument | null> {
+  const resolved = options.basePath
+    ? path.resolve(options.basePath, href)
+    : href;
+  const xml = await fsp.readFile(resolved, "utf-8");
+  const doc = await parseMusicXmlString(xml);
+  if (!doc) return null;
+  return mapDocument(doc, { basePath: path.dirname(resolved) });
+}
+
+function parseLinkedFileSync(
+  href: string,
+  options: MapOptions,
+): ScorePartwise | ScoreTimewise | OpusDocument | null {
+  const resolved = options.basePath
+    ? path.resolve(options.basePath, href)
+    : href;
+  const xml = fs.readFileSync(resolved, "utf-8");
+  const doc = parseMusicXmlStringSync(xml);
+  if (!doc) return null;
+  return mapDocumentSync(doc, { basePath: path.dirname(resolved) });
+}
+
+export async function mapOpusElement(
+  element: Element,
+  options: MapOptions,
+): Promise<OpusDocument> {
+  const title = element.querySelector("title")?.textContent?.trim();
+  const version = element.getAttribute("version") || undefined;
+  const movements: Array<ScorePartwise | ScoreTimewise | OpusDocument> = [];
+  for (const child of Array.from(element.children)) {
+    if (child.nodeName === "score" || child.nodeName === "opus-link") {
+      const href = child.getAttribute("xlink:href");
+      if (href) {
+        const parsed = await parseLinkedFile(href, options);
+        if (parsed) movements.push(parsed);
+      }
+    } else if (child.nodeName === "opus") {
+      movements.push(await mapOpusElement(child, options));
+    }
+  }
+  return { version, title, movements };
+}
+
+export function mapOpusElementSync(
+  element: Element,
+  options: MapOptions,
+): OpusDocument {
+  const title = element.querySelector("title")?.textContent?.trim();
+  const version = element.getAttribute("version") || undefined;
+  const movements: Array<ScorePartwise | ScoreTimewise | OpusDocument> = [];
+  for (const child of Array.from(element.children)) {
+    if (child.nodeName === "score" || child.nodeName === "opus-link") {
+      const href = child.getAttribute("xlink:href");
+      if (href) {
+        const parsed = parseLinkedFileSync(href, options);
+        if (parsed) movements.push(parsed);
+      }
+    } else if (child.nodeName === "opus") {
+      movements.push(mapOpusElementSync(child, options));
+    }
+  }
+  return { version, title, movements };
+}
+
+export function mapDocument(
+  doc: XMLDocument,
+  options: MapOptions,
+): Promise<ScorePartwise | ScoreTimewise | OpusDocument> {
+  const root = doc.documentElement.nodeName;
+  if (root === "score-partwise")
+    return Promise.resolve(mapDocumentToScorePartwise(doc));
+  if (root === "score-timewise")
+    return Promise.resolve(mapDocumentToScoreTimewise(doc));
+  if (root === "opus") return mapOpusElement(doc.documentElement, options);
+  throw new Error(`Unsupported root element <${root}>`);
+}
+
+export function mapDocumentSync(
+  doc: XMLDocument,
+  options: MapOptions,
+): ScorePartwise | ScoreTimewise | OpusDocument {
+  const root = doc.documentElement.nodeName;
+  if (root === "score-partwise") return mapDocumentToScorePartwise(doc);
+  if (root === "score-timewise") return mapDocumentToScoreTimewise(doc);
+  if (root === "opus") return mapOpusElementSync(doc.documentElement, options);
+  throw new Error(`Unsupported root element <${root}>`);
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,6 @@
+import type { ScorePartwise } from "../schemas/scorePartwise";
+import type { ScoreTimewise } from "../schemas/scoreTimewise";
+
 export type { Pitch } from "../schemas/pitch";
 export type { Rest } from "../schemas/rest";
 export type { Note } from "../schemas/note";
@@ -190,3 +193,9 @@ export type {
 export type ParsedMusicXml = Record<string, unknown>;
 export type { PartNameDisplay } from "../schemas/partNameDisplay";
 export type { PartAbbreviationDisplay } from "../schemas/partAbbreviationDisplay";
+
+export interface OpusDocument {
+  version?: string;
+  title?: string;
+  movements: Array<ScorePartwise | ScoreTimewise | OpusDocument>;
+}

--- a/tests/opus-samples/opus.xml
+++ b/tests/opus-samples/opus.xml
@@ -1,0 +1,5 @@
+<opus version="3.1" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <title>Test Opus</title>
+  <score xlink:href="score1.musicxml" />
+  <score xlink:href="score2.musicxml" />
+</opus>

--- a/tests/opus-samples/score1.musicxml
+++ b/tests/opus-samples/score1.musicxml
@@ -1,0 +1,6 @@
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Music</part-name></score-part>
+  </part-list>
+  <part id="P1"><measure number="1"/></part>
+</score-partwise>

--- a/tests/opus-samples/score2.musicxml
+++ b/tests/opus-samples/score2.musicxml
@@ -1,0 +1,6 @@
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Music 2</part-name></score-part>
+  </part-list>
+  <part id="P1"><measure number="1"/></part>
+</score-partwise>

--- a/tests/opus.test.ts
+++ b/tests/opus.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import * as path from "path";
+import * as fs from "fs/promises";
+import { parseMusicXml } from "../src/parser";
+
+const baseDir = path.resolve(__dirname, "opus-samples");
+
+async function read(file: string) {
+  return fs.readFile(path.join(baseDir, file), "utf-8");
+}
+
+describe("Opus root parsing", () => {
+  it("loads referenced movements", async () => {
+    const xml = await read("opus.xml");
+    const opus = await parseMusicXml(xml, { basePath: baseDir });
+    expect(opus && (opus as any).movements).toBeDefined();
+    if (!opus || !("movements" in opus)) return;
+    expect(opus.movements.length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- support `opus` root files
- load linked movements recursively
- expose an `OpusDocument` structure
- add tests with a sample opus referencing two movements

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`
