### PR TITLE
Add advanced MusicXML parsing tests and features

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,5 @@ export * from "./types"; // Zodから推論される型などをエクスポー�
 export * from "./converters";
 export { toMusicXML } from "./converters";
 export * from "./utils/readMusicXmlFile";
+export * from "./utils/opus";
+export * from "./utils/sounds";

--- a/src/parser/mappers/noteMappers.ts
+++ b/src/parser/mappers/noteMappers.ts
@@ -22,8 +22,8 @@ import type {
   MetronomeRelation,
   // Dynamics,
   Wedge,
-  // Segno,
-  //Coda,
+  Segno,
+  Coda,
   Transpose,
   // Diatonic,
   // Chromatic,
@@ -34,6 +34,7 @@ import type {
   LineDetail,
   MeasureStyle,
   MultipleRest,
+  Rest,
   MeasureRepeat,
   BeatRepeat,
   Slash,
@@ -181,6 +182,7 @@ import {
   LineDetailSchema,
   MeasureStyleSchema,
   MultipleRestSchema,
+  RestSchema,
   MeasureRepeatSchema,
   BeatRepeatSchema,
   SlashSchema,
@@ -613,9 +615,14 @@ export const mapNoteElement = (element: Element): Note => {
   } else if (unpitchedElement) {
     noteData.unpitched = mapUnpitchedElement(unpitchedElement);
   } else if (restElement) {
-    noteData.rest = {
-      // measure: getAttribute(restElement, 'measure') === 'yes' ? true : undefined,
-    };
+    const restData: Partial<Rest> = {};
+    const measureAttr = getAttribute(restElement, "measure");
+    if (measureAttr === "yes") restData.measure = true;
+    const ds = getTextContent(restElement, "display-step");
+    if (ds) restData.displayStep = ds;
+    const doOct = parseNumberContent(restElement, "display-octave");
+    if (doOct !== undefined) restData.displayOctave = doOct;
+    noteData.rest = RestSchema.parse(restData);
   }
 
   // Duration is handled based on grace/cue presence by NoteSchema.refine
@@ -1796,6 +1803,9 @@ export const mapMetronomeElement = (element: Element): Metronome => {
     metronomeData["metronome-relation"] =
       relationElement.textContent?.trim() ?? "";
   }
+  const parAttr = getAttribute(element, "parentheses");
+  if (parAttr === "yes" || parAttr === "no")
+    metronomeData.parentheses = parAttr;
   return MetronomeSchema.parse(metronomeData);
 };
 
@@ -1968,10 +1978,28 @@ export const mapDirectionTypeElement = (element: Element): DirectionType => {
     if (img) directionTypeData.image = img;
   }
   if (segnoElement) {
-    directionTypeData.segno = SegnoSchema.parse({});
+    const data: Partial<Segno> = {};
+    const dx = getAttribute(segnoElement, "default-x");
+    if (dx) data.defaultX = parseOptionalFloat(dx);
+    const dy = getAttribute(segnoElement, "default-y");
+    if (dy) data.defaultY = parseOptionalFloat(dy);
+    const rx = getAttribute(segnoElement, "relative-x");
+    if (rx) data.relativeX = parseOptionalFloat(rx);
+    const ry = getAttribute(segnoElement, "relative-y");
+    if (ry) data.relativeY = parseOptionalFloat(ry);
+    directionTypeData.segno = SegnoSchema.parse(data);
   }
   if (codaElement) {
-    directionTypeData.coda = CodaSchema.parse({});
+    const data: Partial<Coda> = {};
+    const dx = getAttribute(codaElement, "default-x");
+    if (dx) data.defaultX = parseOptionalFloat(dx);
+    const dy = getAttribute(codaElement, "default-y");
+    if (dy) data.defaultY = parseOptionalFloat(dy);
+    const rx = getAttribute(codaElement, "relative-x");
+    if (rx) data.relativeX = parseOptionalFloat(rx);
+    const ry = getAttribute(codaElement, "relative-y");
+    if (ry) data.relativeY = parseOptionalFloat(ry);
+    directionTypeData.coda = CodaSchema.parse(data);
   }
   return DirectionTypeSchema.parse(directionTypeData);
 };

--- a/src/schemas/direction.ts
+++ b/src/schemas/direction.ts
@@ -50,7 +50,7 @@ export const MetronomeSchema = z.object({
   "per-minute": MetronomePerMinuteSchema.optional(),
   "metronome-note": z.array(MetronomeNoteSchema).optional(),
   "metronome-relation": z.string().optional(),
-  // parentheses: z.boolean().optional(), // Example attribute
+  parentheses: YesNoEnum.optional(),
 });
 export type Metronome = z.infer<typeof MetronomeSchema>;
 
@@ -85,10 +85,20 @@ export const WedgeSchema = z.object({
 });
 export type Wedge = z.infer<typeof WedgeSchema>;
 
-export const SegnoSchema = z.object({});
+export const SegnoSchema = z.object({
+  defaultX: z.number().optional(),
+  defaultY: z.number().optional(),
+  relativeX: z.number().optional(),
+  relativeY: z.number().optional(),
+});
 export type Segno = z.infer<typeof SegnoSchema>;
 
-export const CodaSchema = z.object({});
+export const CodaSchema = z.object({
+  defaultX: z.number().optional(),
+  defaultY: z.number().optional(),
+  relativeX: z.number().optional(),
+  relativeY: z.number().optional(),
+});
 export type Coda = z.infer<typeof CodaSchema>;
 
 export const OctaveShiftSchema = z.object({

--- a/src/schemas/rest.ts
+++ b/src/schemas/rest.ts
@@ -11,10 +11,9 @@ export const RestSchema = z.object({
    * refers to a full measure rest. It is not typically used for <note> rests.
    * For now, we'll keep it simple and can extend later if needed for <forward>/<backup>.
    */
-  // measure: z.boolean().optional(), // Example: if it were a boolean attribute 'measure="yes"'
-  /** Specifies the visual placement of the rest. Not parsed for now. */
-  // 'display-step': z.string().optional(),
-  // 'display-octave': z.number().int().optional(),
+  measure: z.boolean().optional(),
+  displayStep: z.string().optional(),
+  displayOctave: z.number().int().optional(),
 });
 
 export type Rest = z.infer<typeof RestSchema>;

--- a/src/utils/opus.ts
+++ b/src/utils/opus.ts
@@ -1,0 +1,24 @@
+import { promises as fs } from "fs";
+import * as path from "path";
+import { parseMusicXmlString } from "../parser/xmlParser";
+import { mapDocumentToScorePartwise } from "../parser/mappers";
+import type { ScorePartwise } from "../types";
+
+export async function parseOpusCollection(
+  filePath: string,
+): Promise<ScorePartwise[]> {
+  const xml = await fs.readFile(filePath, "utf8");
+  const doc = await parseMusicXmlString(xml);
+  if (!doc) throw new Error("Invalid opus document");
+  const dir = path.dirname(filePath);
+  const scores: ScorePartwise[] = [];
+  const scoreElements = Array.from(doc.getElementsByTagName("score"));
+  for (const el of scoreElements) {
+    const href = el.getAttribute("xlink:href");
+    if (!href) continue;
+    const scoreXml = await fs.readFile(path.join(dir, href), "utf8");
+    const scoreDoc = await parseMusicXmlString(scoreXml);
+    if (scoreDoc) scores.push(mapDocumentToScorePartwise(scoreDoc));
+  }
+  return scores;
+}

--- a/src/utils/sounds.ts
+++ b/src/utils/sounds.ts
@@ -1,0 +1,23 @@
+import { promises as fs } from "fs";
+import { JSDOM } from "jsdom";
+
+export async function loadSoundsXml(
+  filePath: string,
+): Promise<Map<string, number>> {
+  const data = await fs.readFile(filePath, "utf8");
+  const dom = new JSDOM(data, { contentType: "application/xml" });
+  const map = new Map<string, number>();
+  const soundEls = Array.from(dom.window.document.querySelectorAll("sound"));
+  soundEls.forEach((el, idx) => {
+    const id = el.getAttribute("id");
+    if (id) map.set(id, idx);
+  });
+  return map;
+}
+
+export function instrumentIdForSound(
+  map: Map<string, number>,
+  sound: string,
+): number | undefined {
+  return map.get(sound);
+}

--- a/tests/direction.test.ts
+++ b/tests/direction.test.ts
@@ -80,6 +80,23 @@ describe("Direction parsing", () => {
     expect(met["metronome-note"]?.[1]["metronome-type"]).toBe("eighth");
   });
 
+  it("parses metronome with parentheses", () => {
+    const xml = `<direction><direction-type><metronome parentheses="yes"><beat-unit>quarter</beat-unit><per-minute>100</per-minute></metronome></direction-type></direction>`;
+    const el = createElement(xml);
+    const dir = mapDirectionElement(el);
+    expect(dir.direction_type[0].metronome?.parentheses).toBe("yes");
+  });
+
+  it("parses segno and coda position attributes", () => {
+    const xml = `<direction><direction-type><segno default-x="3" default-y="-2"/><coda relative-x="1" relative-y="2"/></direction-type></direction>`;
+    const el = createElement(xml);
+    const dir = mapDirectionElement(el);
+    expect(dir.direction_type[0].segno?.defaultX).toBe(3);
+    expect(dir.direction_type[0].segno?.defaultY).toBe(-2);
+    expect(dir.direction_type[0].coda?.relativeX).toBe(1);
+    expect(dir.direction_type[0].coda?.relativeY).toBe(2);
+  });
+
   it("parses directive attribute", () => {
     const xml = `<direction directive="yes"><direction-type><words>Tempo</words></direction-type></direction>`;
     const el = createElement(xml);

--- a/tests/fixtures/META-INF/container.xml
+++ b/tests/fixtures/META-INF/container.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0">
+  <rootfiles>
+    <rootfile full-path="score.xml" media-type="application/vnd.recordare.musicxml+xml"/>
+  </rootfiles>
+</container>

--- a/tests/fixtures/collection.opus
+++ b/tests/fixtures/collection.opus
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<opus version="1.0" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <title>Test Collection</title>
+  <score xlink:href="op1.xml" xlink:type="simple"/>
+  <score xlink:href="op2.xml" xlink:type="simple"/>
+</opus>

--- a/tests/fixtures/op1.xml
+++ b/tests/fixtures/op1.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <movement-title>Opus Part 1</movement-title>
+  <part-list>
+    <score-part id="P1"><part-name>Part 1</part-name></score-part>
+  </part-list>
+  <part id="P1"><measure number="1"><note><pitch><step>C</step><octave>4</octave></pitch><duration>1</duration><type>quarter</type></note></measure></part>
+</score-partwise>

--- a/tests/fixtures/op2.xml
+++ b/tests/fixtures/op2.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <movement-title>Opus Part 2</movement-title>
+  <part-list>
+    <score-part id="P1"><part-name>Part 2</part-name></score-part>
+  </part-list>
+  <part id="P1"><measure number="1"><note><pitch><step>D</step><octave>4</octave></pitch><duration>1</duration><type>quarter</type></note></measure></part>
+</score-partwise>

--- a/tests/fixtures/score.xml
+++ b/tests/fixtures/score.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Music</part-name></score-part>
+  </part-list>
+  <part id="P1"><measure number="1">
+    <note><pitch><step>C</step><octave>4</octave></pitch><duration>1</duration><type>quarter</type></note>
+  </measure></part>
+</score-partwise>

--- a/tests/mxlContainer.test.ts
+++ b/tests/mxlContainer.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import * as path from "path";
+import { readMusicXmlFile } from "../src/utils/readMusicXmlFile";
+
+const fixDir = path.resolve(__dirname, "./fixtures");
+
+describe("MXL container handling", () => {
+  it("reads rootfile via container.xml", async () => {
+    const mxl = await readMusicXmlFile(
+      path.join(fixDir, "container-sample.mxl"),
+    );
+    const direct = await readMusicXmlFile(path.join(fixDir, "score.xml"));
+    expect(mxl).toBe(direct);
+  });
+});

--- a/tests/note.test.ts
+++ b/tests/note.test.ts
@@ -56,6 +56,16 @@ describe("Note Schema Tests (note.mod)", () => {
       expect(note.type).toBe("quarter");
     });
 
+    it("parses rest display attributes and measure", () => {
+      const xml =
+        '<note><rest measure="yes"><display-step>D</display-step><display-octave>5</display-octave></rest><duration>4</duration></note>';
+      const el = createElement(xml);
+      const note = mapNoteElement(el);
+      expect(note.rest?.measure).toBe(true);
+      expect(note.rest?.displayStep).toBe("D");
+      expect(note.rest?.displayOctave).toBe(5);
+    });
+
     it("should parse a <note> with <chord>", () => {
       const xml =
         "<note><chord/><pitch><step>E</step><octave>4</octave></pitch><duration>2</duration></note>";

--- a/tests/opusCollection.test.ts
+++ b/tests/opusCollection.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from "vitest";
+import * as path from "path";
+import { parseOpusCollection } from "../src/utils/opus";
+
+describe("opus collection parsing", () => {
+  it("parses referenced scores", async () => {
+    const file = path.join(__dirname, "fixtures", "collection.opus");
+    const scores = await parseOpusCollection(file);
+    expect(scores.length).toBe(2);
+    expect(scores[0].movementTitle).toBe("Opus Part 1");
+    expect(scores[1].movementTitle).toBe("Opus Part 2");
+  });
+});

--- a/tests/sounds.test.ts
+++ b/tests/sounds.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { loadSoundsXml, instrumentIdForSound } from "../src/utils/sounds";
+import * as path from "path";
+
+describe("sounds.xml loading", () => {
+  it("maps instrument ids", async () => {
+    const file = path.resolve(
+      __dirname,
+      "../reference/musicxml-4.0/schema/sounds.xml",
+    );
+    const map = await loadSoundsXml(file);
+    const id = instrumentIdForSound(map, "brass.trumpet");
+    expect(typeof id).toBe("number");
+    expect(id).toBe(map.get("brass.trumpet"));
+  });
+});


### PR DESCRIPTION
## Summary
- support MXL container.xml rootfile lookup
- add parser for opus collections
- parse sounds.xml for instrument IDs
- extend rest schema and mapping
- parse metronome parentheses attribute
- parse segno/coda position attributes
- add comprehensive tests for these features

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`
