### PR TITLE
Add measure helper utilities

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,4 @@ export * from "./types"; // Zodから推論される型などをエクスポー�
 export * from "./converters";
 export { toMusicXML } from "./converters";
 export * from "./utils/readMusicXmlFile";
+export * from "./utils/measureHelpers";

--- a/src/utils/measureHelpers.ts
+++ b/src/utils/measureHelpers.ts
@@ -1,0 +1,85 @@
+// Helpers to extract specific content types from Measure
+
+import type {
+  Measure,
+  Note,
+  Attributes,
+  Direction,
+  Barline,
+  Harmony,
+  Print,
+  Sound,
+  FiguredBass,
+  Grouping,
+  Link,
+  Bookmark,
+  Backup,
+  Forward,
+} from "../types";
+import { LinkSchema } from "../schemas";
+
+function filterByType<T>(measure: Measure, type: string): T[] {
+  const content = measure.content ?? [];
+  return content.filter(
+    (item) => (item as { _type?: string })._type === type,
+  ) as T[];
+}
+
+function filterLinks(measure: Measure): Link[] {
+  const content = measure.content ?? [];
+  return content.filter(
+    (item): item is Link => LinkSchema.safeParse(item).success,
+  );
+}
+
+export function getNotes(measure: Measure): Note[] {
+  return filterByType(measure, "note") as Note[];
+}
+
+export function getAttributes(measure: Measure): Attributes[] {
+  return filterByType(measure, "attributes") as Attributes[];
+}
+
+export function getDirections(measure: Measure): Direction[] {
+  return filterByType(measure, "direction") as Direction[];
+}
+
+export function getBarlines(measure: Measure): Barline[] {
+  return filterByType(measure, "barline") as Barline[];
+}
+
+export function getHarmonies(measure: Measure): Harmony[] {
+  return filterByType(measure, "harmony") as Harmony[];
+}
+
+export function getPrints(measure: Measure): Print[] {
+  return filterByType(measure, "print") as Print[];
+}
+
+export function getSounds(measure: Measure): Sound[] {
+  return filterByType(measure, "sound") as Sound[];
+}
+
+export function getFiguredBasses(measure: Measure): FiguredBass[] {
+  return filterByType(measure, "figured-bass") as FiguredBass[];
+}
+
+export function getGroupings(measure: Measure): Grouping[] {
+  return filterByType(measure, "grouping") as Grouping[];
+}
+
+export function getLinks(measure: Measure): Link[] {
+  return filterLinks(measure);
+}
+
+export function getBookmarks(measure: Measure): Bookmark[] {
+  return filterByType(measure, "bookmark") as Bookmark[];
+}
+
+export function getBackups(measure: Measure): Backup[] {
+  return filterByType(measure, "backup") as Backup[];
+}
+
+export function getForwards(measure: Measure): Forward[] {
+  return filterByType(measure, "forward") as Forward[];
+}

--- a/tests/measureHelpers.test.ts
+++ b/tests/measureHelpers.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { parseMusicXml } from "../src/parser";
+import type { ScorePartwise } from "../src/types";
+import {
+  getNotes,
+  getAttributes,
+  getDirections,
+  getBackups,
+  getForwards,
+  getBarlines,
+} from "../src/utils/measureHelpers";
+
+const xml = `<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1">
+      <part-name>Music</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes><divisions>1</divisions></attributes>
+      <direction placement="above"><direction-type><words>Allegro</words></direction-type></direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>1</duration></note>
+      <backup><duration>1</duration></backup>
+      <note><rest/><duration>1</duration></note>
+      <forward><duration>1</duration></forward>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>1</duration></note>
+      <barline location="right"><bar-style>light-heavy</bar-style></barline>
+    </measure>
+  </part>
+</score-partwise>`;
+
+describe("measureHelpers", () => {
+  it("extracts elements from a measure", async () => {
+    const parsed = (await parseMusicXml(xml)) as ScorePartwise;
+    const measure = parsed.parts[0].measures[0];
+
+    const notes = getNotes(measure);
+    expect(notes).toHaveLength(3);
+    expect(notes[0].pitch?.step).toBe("C");
+    expect(notes[1].rest).toBeDefined();
+
+    const attrs = getAttributes(measure);
+    expect(attrs).toHaveLength(1);
+    expect(attrs[0].divisions).toBe(1);
+
+    const dirs = getDirections(measure);
+    expect(dirs).toHaveLength(1);
+    expect(dirs[0].placement).toBe("above");
+
+    expect(getBackups(measure)).toHaveLength(1);
+    expect(getForwards(measure)).toHaveLength(1);
+    expect(getBarlines(measure)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- create `measureHelpers` utility to access measure content
- export helpers from package entry
- test note/attribute/direction retrieval on parsed score

## Testing
- `npm run format`
- `npm run lint:fix`
- `npm run type-check`
- `npm test`