### PR TITLE
Add measure helper utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For Node.js environments, install `jsdom` (or another DOM implementation) so tha
 The main parsing functionality is exposed through the `parseMusicXmlString` and `mapDocumentToScorePartwise` functions. A convenience wrapper `parseMusicXml` combines these steps. Because `parseMusicXmlString` may dynamically load `jsdom` in Node.js, it is asynchronous and returns a `Promise<Document | null>`.
 
 ```typescript
-import { parseMusicXml, ScorePartwise, Note } from 'your-musicxml-parser-package-name'; // Adjust import path
+import { parseMusicXml, ScorePartwise, getAllNotes } from 'your-musicxml-parser-package-name'; // Adjust import path
 
 const musicXmlString = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
@@ -78,14 +78,8 @@ async function run() {
   console.log("Version:", score.version);
   console.log("First part ID:", score.parts[0]?.id);
 
-  const measure = score.parts[0]?.measures[0];
-  const notes = measure?.content?.filter(
-    (item): item is Note => (item as any)._type === "note",
-  );
-  console.log(
-    "First note in first measure of first part:",
-    notes?.[0],
-  );
+  const notes = getAllNotes(score);
+  console.log("First note in score:", notes[0]);
   // You can now work with the typed 'score' object
 }
 
@@ -110,6 +104,17 @@ const yamlString = toYaml(score);
 const xmlString = toMusicXML(score);
 const toneSeq = toToneJsSequence(score);
 const midi = toMidi(score);
+```
+
+### Helper Utilities
+
+Utility functions are provided to easily access measures and notes:
+
+```typescript
+import { getAllNotes, getAllMeasures } from 'your-musicxml-parser-package-name';
+
+const notes = getAllNotes(score); // all notes in the entire score
+const measuresOfFirstPart = getAllMeasures(score.parts[0]);
 ```
 
 ## Project Structure

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,4 @@ export * from "./types"; // Zodから推論される型などをエクスポー�
 export * from "./converters";
 export { toMusicXML } from "./converters";
 export * from "./utils/readMusicXmlFile";
+export * from "./utils/measureHelpers";

--- a/src/utils/measureHelpers.ts
+++ b/src/utils/measureHelpers.ts
@@ -1,0 +1,26 @@
+import type {
+  Part,
+  Measure,
+  ScorePartwise,
+  Note,
+  MeasureContent,
+} from "../types";
+import { NoteSchema } from "../schemas";
+
+export function getAllMeasures(part: Part): Measure[] {
+  return part.measures;
+}
+
+function isNote(content: MeasureContent): content is Note {
+  return (
+    (content as Note)._type === "note" && NoteSchema.safeParse(content).success
+  );
+}
+
+export function getAllNotes(score: ScorePartwise | Part): Note[] {
+  if (Array.isArray((score as ScorePartwise).parts)) {
+    return (score as ScorePartwise).parts.flatMap((p: Part) => getAllNotes(p));
+  }
+  const part = score as Part;
+  return part.measures.flatMap((m) => (m.content ?? []).filter(isNote));
+}

--- a/tests/measureHelpers.test.ts
+++ b/tests/measureHelpers.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import { parseMusicXmlString } from "../src/parser/xmlParser";
+import { mapDocumentToScorePartwise } from "../src/parser/mappers";
+import { getAllNotes, getAllMeasures } from "../src/utils/measureHelpers";
+
+const filePath = path.resolve(
+  __dirname,
+  "../reference/xmlsamples/MultiPartGroup.musicxml",
+);
+
+describe("measure helper utilities", () => {
+  it("aggregates notes across parts", async () => {
+    const xml = fs.readFileSync(filePath, "utf-8");
+    const doc = await parseMusicXmlString(xml);
+    expect(doc).not.toBeNull();
+    if (!doc) return;
+    const score = mapDocumentToScorePartwise(doc);
+
+    expect(score.parts.length).toBe(2);
+
+    const measuresP1 = getAllMeasures(score.parts[0]);
+    const measuresP2 = getAllMeasures(score.parts[1]);
+    expect(measuresP1.length).toBe(1);
+    expect(measuresP2.length).toBe(1);
+
+    const notes = getAllNotes(score);
+    expect(notes.length).toBe(2);
+    expect(notes[0].pitch?.step).toBe("C");
+    expect(notes[1].pitch?.step).toBe("E");
+  });
+});


### PR DESCRIPTION
## Summary
- add `getAllMeasures` and `getAllNotes` utilities
- expose utilities through public API
- document usage of helper utilities in README
- add unit tests for multi-part aggregation

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`