### PR TITLE
Add part lookup helper

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,4 @@ export * from "./types"; // Zodから推論される型などをエクスポー�
 export * from "./converters";
 export { toMusicXML } from "./converters";
 export * from "./utils/readMusicXmlFile";
+export * from "./utils/partHelpers";

--- a/src/utils/partHelpers.ts
+++ b/src/utils/partHelpers.ts
@@ -1,0 +1,25 @@
+import type { Part, ScorePart, ScorePartwise } from "../types";
+
+export interface PartLookup {
+  part: Part;
+  scorePart: ScorePart;
+}
+
+/**
+ * Find a part within a {@link ScorePartwise} score along with its metadata.
+ *
+ * @param score The parsed score object.
+ * @param id    The identifier of the part to retrieve.
+ * @returns The matching part and its metadata, or `undefined` if not found.
+ */
+export function getPart(
+  score: ScorePartwise,
+  id: string,
+): PartLookup | undefined {
+  const part = (score.parts as Part[]).find((p: Part) => p.id === id);
+  const scorePart = (score.partList.scoreParts as ScorePart[]).find(
+    (sp: ScorePart) => sp.id === id,
+  );
+  if (!part || !scorePart) return undefined;
+  return { part, scorePart };
+}

--- a/tests/partHelpers.test.ts
+++ b/tests/partHelpers.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import { parseMusicXmlString } from "../src/parser/xmlParser";
+import { mapDocumentToScorePartwise } from "../src/parser/mappers";
+import { getPart } from "../src/utils/partHelpers";
+
+const filePath = path.resolve(
+  __dirname,
+  "../reference/xmlsamples/MultiPartGroup.musicxml",
+);
+
+describe("getPart helper", () => {
+  it("returns part and metadata for a given id", async () => {
+    const xmlString = fs.readFileSync(filePath, "utf-8");
+    const doc = await parseMusicXmlString(xmlString);
+    expect(doc).not.toBeNull();
+    if (!doc) return;
+    const score = mapDocumentToScorePartwise(doc);
+
+    const result = getPart(score, "P2");
+    expect(result).toBeDefined();
+    if (!result) return;
+    expect(result.part.id).toBe("P2");
+    expect(result.scorePart.partName).toBe("Cello");
+    expect(result.part.measures.length).toBe(1);
+  });
+
+  it("returns undefined for unknown id", async () => {
+    const xmlString = fs.readFileSync(filePath, "utf-8");
+    const doc = await parseMusicXmlString(xmlString);
+    if (!doc) return;
+    const score = mapDocumentToScorePartwise(doc);
+
+    const result = getPart(score, "PX");
+    expect(result).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- implement `getPart` helper
- expose the helper in the public index
- test lookup with multi-part score

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`
