### PR TITLE
Add basic wrapper utilities

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,4 @@ export * from "./types"; // Zodから推論される型などをエクスポー�
 export * from "./converters";
 export { toMusicXML } from "./converters";
 export * from "./utils/readMusicXmlFile";
+export * from "./wrappers";

--- a/src/wrappers/PartWrapper.ts
+++ b/src/wrappers/PartWrapper.ts
@@ -1,0 +1,29 @@
+import type { Part, ScorePart, Measure, Note } from "../types";
+import { NoteSchema } from "../schemas";
+
+export class PartWrapper {
+  readonly part: Part;
+  readonly scorePart: ScorePart;
+
+  constructor(part: Part, scorePart: ScorePart) {
+    this.part = part;
+    this.scorePart = scorePart;
+  }
+
+  getMeasure(num: number): Measure | undefined {
+    return this.part.measures.find((m) => Number(m.number) === num);
+  }
+
+  getNotes(): Note[] {
+    const notes: Note[] = [];
+    for (const measure of this.part.measures) {
+      if (!measure.content) continue;
+      for (const item of measure.content) {
+        if (NoteSchema.safeParse(item).success) {
+          notes.push(item as Note);
+        }
+      }
+    }
+    return notes;
+  }
+}

--- a/src/wrappers/ScoreWrapper.ts
+++ b/src/wrappers/ScoreWrapper.ts
@@ -1,0 +1,19 @@
+import type { ScorePartwise, Part, ScorePart } from "../types";
+import { PartWrapper } from "./PartWrapper";
+
+export class ScoreWrapper {
+  readonly score: ScorePartwise;
+
+  constructor(score: ScorePartwise) {
+    this.score = score;
+  }
+
+  getPart(id: string): PartWrapper | undefined {
+    const part = this.score.parts.find((p: Part) => p.id === id);
+    const scorePart = this.score.partList.scoreParts.find(
+      (sp: ScorePart) => sp.id === id,
+    );
+    if (!part || !scorePart) return undefined;
+    return new PartWrapper(part, scorePart);
+  }
+}

--- a/src/wrappers/index.ts
+++ b/src/wrappers/index.ts
@@ -1,0 +1,2 @@
+export * from "./PartWrapper";
+export * from "./ScoreWrapper";

--- a/tests/wrapper.test.ts
+++ b/tests/wrapper.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { parseMusicXml } from "../src/parser";
+import { ScoreWrapper } from "../src/wrappers";
+
+const xml = `
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1">
+      <part-name>Music</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1</duration>
+        <type>quarter</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+
+describe("Wrapper classes", () => {
+  it("provides access to parts and notes", async () => {
+    const score = await parseMusicXml(xml);
+    expect(score).not.toBeNull();
+    if (!score) return;
+    const wrapper = new ScoreWrapper(score);
+    const part = wrapper.getPart("P1");
+    expect(part).toBeDefined();
+    if (!part) return;
+    const measure = part.getMeasure(1);
+    expect(measure?.number).toBe("1");
+    const notes = part.getNotes();
+    expect(notes).toHaveLength(1);
+    expect(notes[0].pitch?.step).toBe("C");
+  });
+});


### PR DESCRIPTION
## Summary
- add `PartWrapper` and `ScoreWrapper` classes
- expose wrapper classes in public API
- test wrappers with a minimal example

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`