### PR TITLE
Implement edit helpers for MusicXML scores

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,22 @@ const toneSeq = toToneJsSequence(score);
 const midi = toMidi(score);
 ```
 
+### Editing Helpers
+
+Basic utilities are provided for modifying a parsed `ScorePartwise` object.
+
+```typescript
+import { addNote, transposePart } from 'your-musicxml-parser-package-name';
+
+// Add a note to measure 1 of part P1
+addNote('P1', '1', { _type: 'note', pitch: { step: 'E', octave: 4 }, duration: 1 }, score);
+
+// Transpose all notes in part P1 up a whole tone
+transposePart('P1', 2, score);
+```
+
+Each helper mutates the given score and validates it with `ScorePartwiseSchema.parse`.
+
 ## Project Structure
 
 *   `src/`: Source code

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,4 @@ export * from "./types"; // Zodから推論される型などをエクスポー�
 export * from "./converters";
 export { toMusicXML } from "./converters";
 export * from "./utils/readMusicXmlFile";
+export * from "./utils/editHelpers";

--- a/src/utils/editHelpers.ts
+++ b/src/utils/editHelpers.ts
@@ -1,0 +1,107 @@
+import { ScorePartwiseSchema } from "../schemas/scorePartwise";
+import type { Note, ScorePartwise, Pitch, Part, Measure } from "../types";
+
+function validate(score: ScorePartwise): void {
+  // Throws if invalid
+  ScorePartwiseSchema.parse(score);
+}
+
+/**
+ * Add a note to the specified measure of a part.
+ * The score is validated after the modification.
+ */
+export function addNote(
+  partId: string,
+  measureNo: string,
+  note: Note,
+  score: ScorePartwise,
+): ScorePartwise {
+  const part = score.parts.find((p: Part) => p.id === partId);
+  if (!part) {
+    throw new Error(`Part with id ${partId} not found`);
+  }
+  const measure = part.measures.find((m: Measure) => m.number === measureNo);
+  if (!measure) {
+    throw new Error(`Measure ${measureNo} not found in part ${partId}`);
+  }
+  if (!measure.content) measure.content = [];
+  measure.content.push(note);
+  return validate(score), score;
+}
+
+const STEP_TO_SEMITONE: Record<Pitch["step"], number> = {
+  C: 0,
+  D: 2,
+  E: 4,
+  F: 5,
+  G: 7,
+  A: 9,
+  B: 11,
+};
+
+const SEMITONE_TO_PITCH: Array<Pick<Pitch, "step" | "alter"> | Pitch> = [
+  { step: "C" },
+  { step: "C", alter: 1 },
+  { step: "D" },
+  { step: "D", alter: 1 },
+  { step: "E" },
+  { step: "F" },
+  { step: "F", alter: 1 },
+  { step: "G" },
+  { step: "G", alter: 1 },
+  { step: "A" },
+  { step: "A", alter: 1 },
+  { step: "B" },
+];
+
+function transposePitch(pitch: Pitch, semitones: number): void {
+  const alter = pitch.alter ?? 0;
+  const midi =
+    (pitch.octave + 1) * 12 + STEP_TO_SEMITONE[pitch.step] + alter + semitones;
+  const octave = Math.floor(midi / 12) - 1;
+  let s = midi % 12;
+  if (s < 0) s += 12;
+  const mapping = SEMITONE_TO_PITCH[s];
+  pitch.step = mapping.step as Pitch["step"];
+  if ("alter" in mapping && mapping.alter !== undefined) {
+    pitch.alter = mapping.alter;
+  } else {
+    delete pitch.alter;
+  }
+  pitch.octave = octave;
+}
+
+/**
+ * Transpose all pitched notes in the given part by the specified number of semitones.
+ * The score is validated after transposition.
+ */
+export function transposePart(
+  partId: string,
+  semitones: number,
+  score: ScorePartwise,
+): ScorePartwise {
+  const part = score.parts.find((p: Part) => p.id === partId);
+  if (!part) {
+    throw new Error(`Part with id ${partId} not found`);
+  }
+
+  for (const measure of part.measures) {
+    for (const item of measure.content ?? []) {
+      if ((item as { _type?: string })._type === "note") {
+        const note = item as Note;
+        if (note.pitch) {
+          transposePitch(note.pitch, semitones);
+        }
+      }
+    }
+  }
+
+  return validate(score), score;
+}
+
+export const editHelpers = {
+  addNote,
+  transposePart,
+};
+
+export default editHelpers;

--- a/tests/editHelpers.test.ts
+++ b/tests/editHelpers.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { parseMusicXmlString } from "../src/parser/xmlParser";
+import { mapDocumentToScorePartwise } from "../src/parser/mappers";
+import { addNote, transposePart } from "../src/utils/editHelpers";
+import type { Note } from "../src/types";
+
+const xml = `
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1">
+      <part-name>Music</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1</duration>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+
+async function loadScore() {
+  const doc = await parseMusicXmlString(xml);
+  if (!doc) throw new Error("parse failed");
+  return mapDocumentToScorePartwise(doc);
+}
+
+describe("edit helpers", () => {
+  it("adds a note to a measure", async () => {
+    const score = await loadScore();
+    const newNote: Note = {
+      _type: "note",
+      pitch: { step: "D", octave: 4 },
+      duration: 1,
+    };
+    addNote("P1", "1", newNote, score);
+    const measure = score.parts[0].measures[0];
+    expect(measure.content?.length).toBe(2);
+    const added = measure.content?.[1] as Note;
+    expect(added.pitch?.step).toBe("D");
+  });
+
+  it("transposes all notes in a part", async () => {
+    const score = await loadScore();
+    transposePart("P1", 2, score);
+    const note = score.parts[0].measures[0].content?.[0] as Note;
+    expect(note.pitch?.step).toBe("D");
+  });
+});


### PR DESCRIPTION
## Summary
- implement `addNote` and `transposePart` utilities
- export new helpers from main entry
- document editing helpers in README
- add unit tests for the new helpers

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`