### PR TITLE
Add validation utility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,4 @@ export * from "./types"; // Zodから推論される型などをエクスポー�
 export * from "./converters";
 export { toMusicXML } from "./converters";
 export * from "./utils/readMusicXmlFile";
+export * from "./utils/validation";

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,13 @@
+import { ScorePartwiseSchema } from "../schemas/scorePartwise";
+import type { ScorePartwise } from "../types";
+
+/**
+ * Validate a ScorePartwise object using the corresponding Zod schema.
+ * @throws {ZodError} If validation fails.
+ */
+export function validateScore(score: ScorePartwise): void {
+  const result = ScorePartwiseSchema.safeParse(score);
+  if (!result.success) {
+    throw result.error;
+  }
+}

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { validateScore } from "../src/utils/validation";
+import type { ScorePartwise } from "../src/types";
+
+describe("validateScore", () => {
+  it("throws when required fields are missing", () => {
+    const invalid = { version: "3.1" } as unknown as ScorePartwise;
+    expect(() => validateScore(invalid)).toThrow();
+  });
+
+  it("throws when parts array is empty", () => {
+    const invalid = {
+      version: "3.1",
+      partList: { scoreParts: [{ id: "P1" }] },
+      parts: [],
+    } as unknown as ScorePartwise;
+    expect(() => validateScore(invalid)).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- add utility to validate ScorePartwise objects
- export new validateScore function
- test validation errors for invalid scores

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`
