### PR TITLE
Handle multi-part timing in Tone.js sequence

### DIFF
--- a/src/converters/toMidi.ts
+++ b/src/converters/toMidi.ts
@@ -25,12 +25,17 @@ export interface MidiData {
  */
 export function toMidi(score: ScorePartwise): MidiData {
   const sequence = toToneJsSequence(score);
+  const midiNotes: MidiNote[] = sequence.notes.map((n) => ({
+    time: n.time,
+    duration: n.duration,
+    midi: n.midi,
+  }));
   return {
     header: {
       format: 1,
       numTracks: 1,
       ticksPerBeat: 480,
     },
-    tracks: sequence.notes,
+    tracks: midiNotes,
   };
 }

--- a/tests/converters.test.ts
+++ b/tests/converters.test.ts
@@ -47,6 +47,8 @@ describe("Conversion utilities", () => {
     const seq = toToneJsSequence(score);
     expect(seq.notes.length).toBe(1);
     expect(seq.notes[0].midi).toBe(60);
+    expect(seq.notes[0].time).toBe(0);
+    expect(seq.notes[0].partId).toBe("P1");
     const midi = toMidi(score);
     expect(midi.tracks.length).toBe(1);
     expect(midi.tracks[0].midi).toBe(60);

--- a/tests/toneJsSequence.test.ts
+++ b/tests/toneJsSequence.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { parseMusicXmlString } from "../src/parser/xmlParser";
+import { mapDocumentToScorePartwise } from "../src/parser/mappers";
+import { toToneJsSequence } from "../src/converters";
+
+const multiPartXml = `
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>One</part-name></score-part>
+    <score-part id="P2"><part-name>Two</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1</duration>
+        <type>quarter</type>
+      </note>
+    </measure>
+  </part>
+  <part id="P2">
+    <measure number="1">
+      <note>
+        <pitch><step>E</step><octave>4</octave></pitch>
+        <duration>1</duration>
+        <type>quarter</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+
+const multiVoiceXml = `
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Music</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <backup><duration>4</duration></backup>
+      <note>
+        <pitch><step>E</step><octave>4</octave></pitch>
+        <duration>4</duration>
+        <voice>2</voice>
+        <type>whole</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+
+describe("toToneJsSequence multi-track timing", () => {
+  it("places notes from different parts at the same time", async () => {
+    const doc = await parseMusicXmlString(multiPartXml);
+    if (!doc) throw new Error("parse failed");
+    const score = mapDocumentToScorePartwise(doc);
+    const seq = toToneJsSequence(score);
+    expect(seq.notes).toHaveLength(2);
+    const times = seq.notes.map((n) => n.time);
+    expect(times).toEqual([0, 0]);
+    const parts = seq.notes.map((n) => n.partId);
+    expect(parts).toEqual(["P1", "P2"]);
+  });
+
+  it("handles voices with backups", async () => {
+    const doc = await parseMusicXmlString(multiVoiceXml);
+    if (!doc) throw new Error("parse failed");
+    const score = mapDocumentToScorePartwise(doc);
+    const seq = toToneJsSequence(score);
+    expect(seq.notes).toHaveLength(2);
+    const times = seq.notes.map((n) => n.time);
+    expect(times).toEqual([0, 0]);
+    const voices = seq.notes.map((n) => n.voice);
+    expect(voices).toEqual(["1", "2"]);
+  });
+});


### PR DESCRIPTION
## Summary
- enrich `ToneJsNote` with part and voice info
- compute timing per part in `toToneJsSequence`
- strip extra fields when converting to MIDI
- update converter test
- add new test covering multi-part and multi-voice timing

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`