### PR TITLE
Add multi-track MIDI conversion

### DIFF
--- a/src/converters/toMidi.ts
+++ b/src/converters/toMidi.ts
@@ -1,4 +1,4 @@
-import type { ScorePartwise } from "../types";
+import type { ScorePartwise, ScorePart } from "../types";
 import { toToneJsSequence } from "./toToneJsSequence";
 
 export interface MidiHeader {
@@ -15,7 +15,15 @@ export interface MidiNote {
 
 export interface MidiData {
   header: MidiHeader;
-  tracks: MidiNote[];
+  /**
+   * Each inner array represents a MIDI track. Notes within a track share the
+   * same channel and program when provided by the corresponding ScorePart.
+   */
+  tracks: MidiNote[][];
+  /** MIDI channel numbers for each track (1-16) */
+  channels?: Array<number | undefined>;
+  /** MIDI program numbers for each track (1-128) */
+  programs?: Array<number | undefined>;
 }
 
 /**
@@ -24,13 +32,31 @@ export interface MidiData {
  * fed into a MIDI library.
  */
 export function toMidi(score: ScorePartwise): MidiData {
-  const sequence = toToneJsSequence(score);
+  const tracks: MidiNote[][] = [];
+  const channels: Array<number | undefined> = [];
+  const programs: Array<number | undefined> = [];
+
+  for (const part of score.parts) {
+    const partScore: ScorePartwise = { ...score, parts: [part] };
+    const sequence = toToneJsSequence(partScore);
+    tracks.push(sequence.notes);
+
+    const meta = (score.partList.scoreParts as ScorePart[]).find(
+      (p: ScorePart) => p.id === part.id,
+    );
+    const midiInfo = meta?.midiInstruments?.[0];
+    channels.push(midiInfo?.midiChannel);
+    programs.push(midiInfo?.midiProgram);
+  }
+
   return {
     header: {
       format: 1,
-      numTracks: 1,
+      numTracks: tracks.length,
       ticksPerBeat: 480,
     },
-    tracks: sequence.notes,
+    tracks,
+    channels,
+    programs,
   };
 }

--- a/tests/converters.test.ts
+++ b/tests/converters.test.ts
@@ -49,7 +49,44 @@ describe("Conversion utilities", () => {
     expect(seq.notes[0].midi).toBe(60);
     const midi = toMidi(score);
     expect(midi.tracks.length).toBe(1);
-    expect(midi.tracks[0].midi).toBe(60);
+    expect(midi.tracks[0][0].midi).toBe(60);
+  });
+
+  it("creates multiple MIDI tracks for multiple parts", async () => {
+    const multiXml = `
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1">
+      <part-name>First</part-name>
+    </score-part>
+    <score-part id="P2">
+      <part-name>Second</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1</duration>
+      </note>
+    </measure>
+  </part>
+  <part id="P2">
+    <measure number="1">
+      <note>
+        <pitch><step>E</step><octave>4</octave></pitch>
+        <duration>1</duration>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+    const doc2 = await parseMusicXmlString(multiXml);
+    if (!doc2) throw new Error("parse failed");
+    const score2 = mapDocumentToScorePartwise(doc2);
+    const midi2 = toMidi(score2);
+    expect(midi2.tracks.length).toBe(2);
+    expect(midi2.tracks[0][0].midi).toBe(60);
+    expect(midi2.tracks[1][0].midi).toBe(64);
   });
 
   it("serializes back to MusicXML", async () => {


### PR DESCRIPTION
## Summary
- update MidiData structure to support multiple tracks
- build MIDI tracks per part with optional channel/program
- verify multi-track MIDI output in converters tests

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`