### PR TITLE
Add MIDI import capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ import {
   toYaml,
   toToneJsSequence,
   toMidi,
+  fromMidi,
   toMusicXML,
 } from 'your-musicxml-parser-package-name';
 

--- a/src/importers/fromMidi.ts
+++ b/src/importers/fromMidi.ts
@@ -1,0 +1,174 @@
+import type { ScorePartwise, MeasureContent, Note, Pitch } from "../types";
+
+interface MidiHeader {
+  format: number;
+  numTracks: number;
+  ticksPerBeat: number;
+}
+
+interface MidiNote {
+  time: number;
+  duration: number;
+  midi: number;
+}
+
+function readVar(data: Uint8Array, posObj: { value: number }): number {
+  let result = 0;
+  while (true) {
+    const b = data[posObj.value++];
+    result = (result << 7) | (b & 0x7f);
+    if ((b & 0x80) === 0) break;
+  }
+  return result;
+}
+
+function parseMidi(data: Uint8Array): {
+  header: MidiHeader;
+  notes: MidiNote[];
+} {
+  let pos = 0;
+  const readStr = (n: number) => {
+    const s = String.fromCharCode(...data.slice(pos, pos + n));
+    pos += n;
+    return s;
+  };
+  const readU32 = () => {
+    const v =
+      (data[pos] << 24) |
+      (data[pos + 1] << 16) |
+      (data[pos + 2] << 8) |
+      data[pos + 3];
+    pos += 4;
+    return v >>> 0;
+  };
+  const readU16 = () => {
+    const v = (data[pos] << 8) | data[pos + 1];
+    pos += 2;
+    return v;
+  };
+
+  if (readStr(4) !== "MThd") throw new Error("Invalid MIDI header");
+  const headerLength = readU32();
+  const format = readU16();
+  const numTracks = readU16();
+  const ticksPerBeat = readU16();
+  pos += headerLength - 6;
+
+  const notes: MidiNote[] = [];
+
+  for (let t = 0; t < numTracks; t++) {
+    if (readStr(4) !== "MTrk") throw new Error("Invalid track header");
+    const length = readU32();
+    const trackEnd = pos + length;
+    let time = 0;
+    let status = 0;
+    const active = new Map<number, number>();
+
+    while (pos < trackEnd) {
+      const deltaPos = { value: pos };
+      const delta = readVar(data, deltaPos);
+      pos = deltaPos.value;
+      time += delta;
+      let b = data[pos++];
+      if (b >= 0x80) {
+        status = b;
+      } else {
+        // running status
+        pos--;
+        b = status;
+      }
+      if (status === 0xff) {
+        // meta event
+        pos++; // type
+        const lenPos = { value: pos };
+        const len = readVar(data, lenPos);
+        pos = lenPos.value + len;
+        continue;
+      }
+      if (status === 0xf0 || status === 0xf7) {
+        const lenPos = { value: pos };
+        const len = readVar(data, lenPos);
+        pos = lenPos.value + len;
+        continue;
+      }
+      const eventType = status & 0xf0;
+      if (eventType === 0x90) {
+        const note = data[pos++];
+        const vel = data[pos++];
+        if (vel === 0) {
+          const start = active.get(note);
+          if (start !== undefined) {
+            active.delete(note);
+            notes.push({ time: start, duration: time - start, midi: note });
+          }
+        } else {
+          active.set(note, time);
+        }
+      } else if (eventType === 0x80) {
+        const note = data[pos++];
+        pos++; // velocity
+        const start = active.get(note);
+        if (start !== undefined) {
+          active.delete(note);
+          notes.push({ time: start, duration: time - start, midi: note });
+        }
+      } else {
+        if (eventType === 0xc0 || eventType === 0xd0) {
+          pos++;
+        } else {
+          pos += 2;
+        }
+      }
+    }
+  }
+  notes.sort((a, b) => a.time - b.time);
+  return { header: { format, numTracks, ticksPerBeat }, notes };
+}
+
+function midiToPitch(midi: number): Pitch {
+  const map: Array<[Pitch["step"], number]> = [
+    ["C", 0],
+    ["C", 1],
+    ["D", 0],
+    ["D", 1],
+    ["E", 0],
+    ["F", 0],
+    ["F", 1],
+    ["G", 0],
+    ["G", 1],
+    ["A", 0],
+    ["A", 1],
+    ["B", 0],
+  ];
+  const semitone = midi % 12;
+  const octave = Math.floor(midi / 12) - 1;
+  const [step, alter] = map[semitone];
+  if (alter !== 0) {
+    return { step, alter, octave };
+  }
+  return { step, octave };
+}
+
+export function fromMidi(data: Uint8Array): ScorePartwise {
+  const { header: _header, notes } = parseMidi(data);
+  const contents: MeasureContent[] = [];
+  let time = 0;
+  for (const n of notes) {
+    if (n.time > time) {
+      const rest: Note = { _type: "note", rest: {}, duration: n.time - time };
+      contents.push(rest);
+      time = n.time;
+    }
+    const pitch = midiToPitch(n.midi);
+    const note: Note = { _type: "note", pitch, duration: n.duration };
+    contents.push(note);
+    time = n.time + n.duration;
+  }
+  const score: ScorePartwise = {
+    version: "1.0",
+    partList: { scoreParts: [{ id: "P1", partName: "MIDI Import" }] },
+    parts: [{ id: "P1", measures: [{ number: "1", content: contents }] }],
+  };
+  // Preserve ticksPerBeat by storing in defaults? For now ignore header
+  return score;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,4 @@ export * from "./types"; // Zodから推論される型などをエクスポー�
 export * from "./converters";
 export { toMusicXML } from "./converters";
 export * from "./utils/readMusicXmlFile";
+export { fromMidi } from "./importers/fromMidi";

--- a/tests/fromMidi.test.ts
+++ b/tests/fromMidi.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { fromMidi } from "../src/importers/fromMidi";
+import { toMidi } from "../src/converters";
+
+const midiData = new Uint8Array([
+  0x4d, 0x54, 0x68, 0x64, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00, 0x01, 0x01,
+  0xe0, 0x4d, 0x54, 0x72, 0x6b, 0x00, 0x00, 0x00, 0x0d, 0x00, 0x90, 0x3c, 0x40,
+  0x83, 0x60, 0x80, 0x3c, 0x40, 0x00, 0xff, 0x2f, 0x00,
+]);
+
+describe("fromMidi", () => {
+  it("parses a simple MIDI file", () => {
+    const score = fromMidi(midiData);
+    expect(score.parts.length).toBe(1);
+    expect(score.parts[0].measures[0].content.length).toBe(1);
+    const midi = toMidi(score);
+    expect(midi.header.ticksPerBeat).toBe(480);
+    expect(midi.tracks.length).toBe(1);
+    expect(midi.tracks[0].midi).toBe(60);
+    expect(midi.tracks[0].duration).toBe(480);
+  });
+});


### PR DESCRIPTION
## Summary
- add `fromMidi` importer for reading simple MIDI files
- expose importer from public API
- document usage in README
- test round-trip conversion from MIDI

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`