### PR TITLE
Improve MusicXML serialization

### DIFF
--- a/src/converters/toMusicXML.ts
+++ b/src/converters/toMusicXML.ts
@@ -1,7 +1,148 @@
-import type { ScorePartwise, Note, MeasureContent } from "../types";
+import type {
+  ScorePartwise,
+  Note,
+  MeasureContent,
+  Attributes,
+  Direction,
+  Barline,
+  ScoreInstrument,
+  MidiInstrument,
+  MidiDevice,
+} from "../types";
 
 function indent(level: number): string {
   return "  ".repeat(level);
+}
+
+function serializeNote(note: Note, level: number, lines: string[]): void {
+  lines.push(`${indent(level)}<note>`);
+  if (note.pitch) {
+    lines.push(`${indent(level + 1)}<pitch>`);
+    lines.push(`${indent(level + 2)}<step>${note.pitch.step}</step>`);
+    if (note.pitch.alter !== undefined) {
+      lines.push(`${indent(level + 2)}<alter>${note.pitch.alter}</alter>`);
+    }
+    lines.push(`${indent(level + 2)}<octave>${note.pitch.octave}</octave>`);
+    lines.push(`${indent(level + 1)}</pitch>`);
+  } else if (note.rest) {
+    lines.push(`${indent(level + 1)}<rest/>`);
+  }
+  if (note.duration !== undefined) {
+    lines.push(`${indent(level + 1)}<duration>${note.duration}</duration>`);
+  }
+  if (note.type) {
+    lines.push(`${indent(level + 1)}<type>${note.type}</type>`);
+  }
+  lines.push(`${indent(level)}</note>`);
+}
+
+function serializeAttributes(
+  attrs: Attributes,
+  level: number,
+  lines: string[],
+): void {
+  lines.push(`${indent(level)}<attributes>`);
+  if (attrs.divisions !== undefined) {
+    lines.push(`${indent(level + 1)}<divisions>${attrs.divisions}</divisions>`);
+  }
+  if (attrs.key) {
+    for (const k of attrs.key) {
+      lines.push(`${indent(level + 1)}<key>`);
+      lines.push(`${indent(level + 2)}<fifths>${k.fifths}</fifths>`);
+      if (k.mode) lines.push(`${indent(level + 2)}<mode>${k.mode}</mode>`);
+      lines.push(`${indent(level + 1)}</key>`);
+    }
+  }
+  if (attrs.time) {
+    for (const t of attrs.time) {
+      lines.push(`${indent(level + 1)}<time>`);
+      if (t.beats && t["beat-type"]) {
+        lines.push(`${indent(level + 2)}<beats>${t.beats}</beats>`);
+        lines.push(
+          `${indent(level + 2)}<beat-type>${t["beat-type"]}</beat-type>`,
+        );
+      } else if (t.senzaMisura) {
+        lines.push(`${indent(level + 2)}<senza-misura/>`);
+      }
+      lines.push(`${indent(level + 1)}</time>`);
+    }
+  }
+  if (attrs.clef) {
+    for (const c of attrs.clef) {
+      const attrsStr = c.number !== undefined ? ` number="${c.number}"` : "";
+      lines.push(`${indent(level + 1)}<clef${attrsStr}>`);
+      lines.push(`${indent(level + 2)}<sign>${c.sign}</sign>`);
+      if (c.line !== undefined)
+        lines.push(`${indent(level + 2)}<line>${c.line}</line>`);
+      lines.push(`${indent(level + 1)}</clef>`);
+    }
+  }
+  if (attrs.staves !== undefined) {
+    lines.push(`${indent(level + 1)}<staves>${attrs.staves}</staves>`);
+  }
+  if (attrs.instruments !== undefined) {
+    lines.push(
+      `${indent(level + 1)}<instruments>${attrs.instruments}</instruments>`,
+    );
+  }
+  lines.push(`${indent(level)}</attributes>`);
+}
+
+function serializeDirection(
+  direction: Direction,
+  level: number,
+  lines: string[],
+): void {
+  let attrsStr = "";
+  if (direction.placement) attrsStr += ` placement="${direction.placement}"`;
+  if (direction.staff !== undefined) attrsStr += ` staff="${direction.staff}"`;
+  if (direction.directive) attrsStr += ` directive="${direction.directive}"`;
+  lines.push(`${indent(level)}<direction${attrsStr}>`);
+  for (const dt of direction.direction_type) {
+    lines.push(`${indent(level + 1)}<direction-type>`);
+    if (dt.words) {
+      lines.push(`${indent(level + 2)}<words>${dt.words.text}</words>`);
+    }
+    if (dt.dynamics) {
+      lines.push(`${indent(level + 2)}<dynamics>`);
+      lines.push(`${indent(level + 3)}<${dt.dynamics.value}/>`);
+      lines.push(`${indent(level + 2)}</dynamics>`);
+    }
+    lines.push(`${indent(level + 1)}</direction-type>`);
+  }
+  if (direction.offset !== undefined) {
+    lines.push(`${indent(level + 1)}<offset>${direction.offset}</offset>`);
+  }
+  if (direction.sound && direction.sound.tempo !== undefined) {
+    lines.push(`${indent(level + 1)}<sound tempo="${direction.sound.tempo}"/>`);
+  }
+  lines.push(`${indent(level)}</direction>`);
+}
+
+function serializeBarline(
+  barline: Barline,
+  level: number,
+  lines: string[],
+): void {
+  const attrsStr = barline.location ? ` location="${barline.location}"` : "";
+  lines.push(`${indent(level)}<barline${attrsStr}>`);
+  if (barline.barStyle) {
+    const color = barline.barStyleColor
+      ? ` color="${barline.barStyleColor}"`
+      : "";
+    lines.push(
+      `${indent(level + 1)}<bar-style${color}>${barline.barStyle}</bar-style>`,
+    );
+  }
+  if (barline.repeat) {
+    const r = barline.repeat;
+    let attrs = ` direction="${r.direction}"`;
+    if (r.times !== undefined) attrs += ` times="${r.times}"`;
+    if (r.winged) attrs += ` winged="${r.winged}"`;
+    if (r.afterJump) attrs += ` after-jump="${r.afterJump}"`;
+    lines.push(`${indent(level + 1)}<repeat${attrs}/>`);
+  }
+  lines.push(`${indent(level)}</barline>`);
 }
 
 /** Serialize a ScorePartwise object into a minimal MusicXML string. */
@@ -17,12 +158,63 @@ export function toMusicXML(score: ScorePartwise): string {
     if (part.partName) {
       lines.push(`${indent(3)}<part-name>${part.partName}</part-name>`);
     }
+    if (part.partAbbreviation) {
+      lines.push(
+        `${indent(3)}<part-abbreviation>${part.partAbbreviation}</part-abbreviation>`,
+      );
+    }
+    if (part.scoreInstruments) {
+      for (const instr of part.scoreInstruments as ScoreInstrument[]) {
+        lines.push(`${indent(3)}<score-instrument id="${instr.id}">`);
+        lines.push(
+          `${indent(4)}<instrument-name>${instr.instrumentName}</instrument-name>`,
+        );
+        if (instr.instrumentSound)
+          lines.push(
+            `${indent(4)}<instrument-sound>${instr.instrumentSound}</instrument-sound>`,
+          );
+        lines.push(`${indent(3)}</score-instrument>`);
+      }
+    }
+    if (part.midiDevices) {
+      for (const dev of part.midiDevices as MidiDevice[]) {
+        let attrs = dev.id ? ` id="${dev.id}"` : "";
+        if (dev.port !== undefined) attrs += ` port="${dev.port}"`;
+        lines.push(
+          `${indent(3)}<midi-device${attrs}>${dev.value}</midi-device>`,
+        );
+      }
+    }
+    if (part.midiInstruments) {
+      for (const mi of part.midiInstruments as MidiInstrument[]) {
+        lines.push(`${indent(3)}<midi-instrument id="${mi.id}">`);
+        if (mi.midiChannel !== undefined)
+          lines.push(
+            `${indent(4)}<midi-channel>${mi.midiChannel}</midi-channel>`,
+          );
+        if (mi.midiProgram !== undefined)
+          lines.push(
+            `${indent(4)}<midi-program>${mi.midiProgram}</midi-program>`,
+          );
+        if (mi.volume !== undefined)
+          lines.push(`${indent(4)}<volume>${mi.volume}</volume>`);
+        if (mi.pan !== undefined)
+          lines.push(`${indent(4)}<pan>${mi.pan}</pan>`);
+        lines.push(`${indent(3)}</midi-instrument>`);
+      }
+    }
     lines.push(`${indent(2)}</score-part>`);
   }
   lines.push(`${indent(1)}</part-list>`);
 
   const isNote = (mc: MeasureContent): mc is Note =>
     (mc as Note)._type === "note";
+  const isAttributes = (mc: MeasureContent): mc is Attributes =>
+    (mc as Attributes)._type === "attributes";
+  const isDirection = (mc: MeasureContent): mc is Direction =>
+    (mc as Direction)._type === "direction";
+  const isBarline = (mc: MeasureContent): mc is Barline =>
+    (mc as Barline)._type === "barline";
 
   // Parts
   for (const part of score.parts) {
@@ -32,25 +224,13 @@ export function toMusicXML(score: ScorePartwise): string {
       if (measure.content) {
         for (const item of measure.content) {
           if (isNote(item)) {
-            lines.push(`${indent(3)}<note>`);
-            if (item.pitch) {
-              lines.push(`${indent(4)}<pitch>`);
-              lines.push(`${indent(5)}<step>${item.pitch.step}</step>`);
-              if (item.pitch.alter !== undefined) {
-                lines.push(`${indent(5)}<alter>${item.pitch.alter}</alter>`);
-              }
-              lines.push(`${indent(5)}<octave>${item.pitch.octave}</octave>`);
-              lines.push(`${indent(4)}</pitch>`);
-            } else if (item.rest) {
-              lines.push(`${indent(4)}<rest/>`);
-            }
-            if (item.duration !== undefined) {
-              lines.push(`${indent(4)}<duration>${item.duration}</duration>`);
-            }
-            if (item.type) {
-              lines.push(`${indent(4)}<type>${item.type}</type>`);
-            }
-            lines.push(`${indent(3)}</note>`);
+            serializeNote(item, 3, lines);
+          } else if (isAttributes(item)) {
+            serializeAttributes(item, 3, lines);
+          } else if (isDirection(item)) {
+            serializeDirection(item, 3, lines);
+          } else if (isBarline(item)) {
+            serializeBarline(item, 3, lines);
           }
         }
       }

--- a/tests/toMusicXML.test.ts
+++ b/tests/toMusicXML.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { parseMusicXmlString } from "../src/parser/xmlParser";
+import { mapDocumentToScorePartwise } from "../src/parser/mappers";
+import type { MeasureContent } from "../src/types";
+import { toMusicXML } from "../src/converters";
+
+const xml = `
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1">
+      <part-name>Flute</part-name>
+      <part-abbreviation>Fl.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Flute</instrument-name>
+      </score-instrument>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>74</midi-program>
+      </midi-instrument>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction placement="above">
+        <direction-type><words>Allegro</words></direction-type>
+      </direction>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1</duration>
+        <type>quarter</type>
+      </note>
+      <barline location="right"><bar-style>light-heavy</bar-style><repeat direction="backward"/></barline>
+    </measure>
+  </part>
+</score-partwise>`;
+
+describe("toMusicXML serialization", () => {
+  it("preserves basic elements when serializing and parsing back", async () => {
+    const doc = await parseMusicXmlString(xml);
+    if (!doc) throw new Error("parse failed");
+    const score1 = mapDocumentToScorePartwise(doc);
+    const xmlOut = toMusicXML(score1);
+    const doc2 = await parseMusicXmlString(xmlOut);
+    if (!doc2) throw new Error("reparse failed");
+    const score2 = mapDocumentToScorePartwise(doc2);
+
+    const part = score2.partList.scoreParts[0];
+    expect(part.partAbbreviation).toBe("Fl.");
+    expect(part.scoreInstruments?.[0].instrumentName).toBe("Flute");
+    expect(part.midiInstruments?.[0].midiProgram).toBe(74);
+
+    const measure = score2.parts[0].measures[0];
+    const attrs = measure.content?.find(
+      (c: MeasureContent) => (c as any)._type === "attributes",
+    ) as any;
+    expect(attrs.divisions).toBe(1);
+    const dir = measure.content?.find(
+      (c: MeasureContent) => (c as any)._type === "direction",
+    ) as any;
+    expect(dir.direction_type[0].words.text).toBe("Allegro");
+    const bar = measure.content?.find(
+      (c: MeasureContent) => (c as any)._type === "barline",
+    ) as any;
+    expect(bar.repeat.direction).toBe("backward");
+  });
+});


### PR DESCRIPTION
## Summary
- extend MusicXML serializer to output attributes, directions, barlines
- include part metadata (abbreviation and instrument info)
- add tests covering round‑trip serialization with extra features

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`