### PR TITLE
Add derived measure lists

### DIFF
--- a/src/parser/mappers/measureMappers.ts
+++ b/src/parser/mappers/measureMappers.ts
@@ -43,6 +43,7 @@ import type {
   Print,
   Sound,
   MeasureContent,
+  Note,
   StaffLayout,
   TimewisePart,
   TimewiseMeasure,
@@ -56,6 +57,8 @@ import type {
   MidiDevice,
   FiguredBass,
   Figure,
+  Link,
+  Bookmark,
   InstrumentChange,
   Grouping,
   Feature,
@@ -1112,6 +1115,47 @@ export function mapMeasureElement(measureElement: Element): Measure {
     width: widthAttr ? parseOptionalFloat(widthAttr) : undefined,
     content: content.length > 0 ? content : undefined,
   };
+
+  // Derive convenience lists from content
+  if (measureData.content) {
+    const filterByType = <T extends MeasureContent>(type: string): T[] =>
+      measureData
+        .content!.filter(
+          (c): c is T =>
+            typeof c === "object" &&
+            c !== null &&
+            "_type" in c &&
+            (c as { _type: string })._type === type,
+        )
+        .map((c) => c as T);
+
+    const notes = filterByType<Note>("note");
+    if (notes.length) measureData.notes = notes;
+    const attrs = filterByType<Attributes>("attributes");
+    if (attrs.length) measureData.attributesElements = attrs;
+    const dirs = filterByType<Direction>("direction");
+    if (dirs.length) measureData.directions = dirs;
+    const barlines = filterByType<Barline>("barline");
+    if (barlines.length) measureData.barlines = barlines;
+    const harmonies = filterByType<Harmony>("harmony");
+    if (harmonies.length) measureData.harmonies = harmonies;
+    const prints = filterByType<Print>("print");
+    if (prints.length) measureData.prints = prints;
+    const sounds = filterByType<Sound>("sound");
+    if (sounds.length) measureData.sounds = sounds;
+    const figured = filterByType<FiguredBass>("figured-bass");
+    if (figured.length) measureData.figuredBasses = figured;
+    const groupings = filterByType<Grouping>("grouping");
+    if (groupings.length) measureData.groupings = groupings;
+    const links = filterByType<Link>("link");
+    if (links.length) measureData.links = links;
+    const bookmarks = filterByType<Bookmark>("bookmark");
+    if (bookmarks.length) measureData.bookmarks = bookmarks;
+    const backups = filterByType<Backup>("backup");
+    if (backups.length) measureData.backups = backups;
+    const forwards = filterByType<Forward>("forward");
+    if (forwards.length) measureData.forwards = forwards;
+  }
 
   // Remove undefined properties from measureData before parsing
   const cleanedMeasureData = Object.fromEntries(

--- a/src/schemas/measure.ts
+++ b/src/schemas/measure.ts
@@ -39,6 +39,20 @@ export const MeasureSchema = z.object({
   nonControlling: z.boolean().optional(),
   width: z.number().optional(),
   content: z.array(MeasureContentSchema).optional().default([]),
+  /** Convenience lists extracted from `content`. */
+  notes: z.array(NoteSchema).optional().readonly(),
+  directions: z.array(DirectionSchema).optional().readonly(),
+  attributesElements: z.array(AttributesSchema).optional().readonly(),
+  barlines: z.array(BarlineSchema).optional().readonly(),
+  harmonies: z.array(HarmonySchema).optional().readonly(),
+  prints: z.array(PrintSchema).optional().readonly(),
+  sounds: z.array(SoundSchema).optional().readonly(),
+  figuredBasses: z.array(FiguredBassSchema).optional().readonly(),
+  groupings: z.array(GroupingSchema).optional().readonly(),
+  links: z.array(LinkSchema).optional().readonly(),
+  bookmarks: z.array(BookmarkSchema).optional().readonly(),
+  backups: z.array(BackupSchema).optional().readonly(),
+  forwards: z.array(ForwardSchema).optional().readonly(),
   // The 'passthrough()' below was removed as explicit content modeling is preferred.
   // If truly unknown elements need to be captured, a specific 'any' or 'unknown'
   // type could be added to the union, or passthrough could be re-enabled with caution.

--- a/src/schemas/part.ts
+++ b/src/schemas/part.ts
@@ -5,7 +5,8 @@ import { MeasureSchema } from "./measure";
  * Represents a single part in a score (e.g., a single instrument or voice).
  * Each part contains a sequence of measures.
  */
-export const PartSchema = z
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const PartSchema: z.ZodType<any> = z
   .object({
     /**
      * A unique identifier for this part. This ID should correspond to an ID

--- a/tests/chant.test.ts
+++ b/tests/chant.test.ts
@@ -149,6 +149,7 @@ describe("Chant.musicxml Parser Test", () => {
     const attributesArray = getAttributesFromContent(measure1.content);
     expect(attributesArray).toHaveLength(1);
     const attrs = attributesArray[0];
+    expect(measure1.attributesElements?.length).toBe(attributesArray.length);
     expect(attrs?.divisions).toBe(8);
     expect(attrs?.key?.[0].fifths).toBe(0);
     // Check for <senza-misura/>
@@ -160,6 +161,7 @@ describe("Chant.musicxml Parser Test", () => {
 
     // Check direction
     const directionsArray = getDirectionsFromContent(measure1.content);
+    expect(measure1.directions?.length).toBe(directionsArray.length);
     expect(directionsArray.length).toBeGreaterThanOrEqual(1); // At least "Angelus dicit:"
     const angelusDirection = directionsArray.find(
       (d) => d.direction_type?.[0]?.words?.text === "Angelus dicit:",
@@ -170,6 +172,7 @@ describe("Chant.musicxml Parser Test", () => {
 
     // Check notes and lyrics
     const notesArray = getNotesFromContent(measure1.content);
+    expect(measure1.notes?.length).toBe(notesArray.length);
     expect(notesArray.length).toBeGreaterThanOrEqual(26); // Based on the provided XML for measure 1
 
     const firstNote = notesArray[0];
@@ -199,13 +202,9 @@ describe("Chant.musicxml Parser Test", () => {
     // If the barline is a direct property of the measure (e.g., measure.barlines), test that instead.
     // Based on Chant.xml, the barline is a direct child, not in a 'content' array per se in the typical sense.
     // It will be mapped as a MeasureContent item with _type: 'barline'.
-    const barlineElement = measure1.content?.find(
-      (item: any) => (item as any)._type === "barline",
-    );
+    const barlineElement = measure1.barlines?.[0];
     expect(barlineElement).toBeDefined();
-    // @ts-ignore
     expect(barlineElement?.location).toBe("right");
-    // @ts-ignore
     expect(barlineElement?.barStyle).toBe("light-light");
   });
 

--- a/tests/echigo-jishi.test.ts
+++ b/tests/echigo-jishi.test.ts
@@ -258,6 +258,7 @@ describe("Echigo-Jishi.musicxml Parser Test", () => {
     expect(attributesArray).toBeDefined();
     expect(attributesArray).toHaveLength(1);
     const attrs = attributesArray[0];
+    expect(measure1.attributesElements?.length).toBe(attributesArray.length);
     expect(attrs?.divisions).toBe(8);
     expect(attrs?.key?.[0].fifths).toBe(0);
     expect(attrs?.time?.[0].beats).toBe("2");
@@ -267,6 +268,7 @@ describe("Echigo-Jishi.musicxml Parser Test", () => {
     // Check <direction> elements - Partially implemented
     const directionsArray = getDirectionsFromContent(measure1.content);
     expect(directionsArray).toBeDefined();
+    expect(measure1.directions?.length).toBe(directionsArray.length);
     expect(directionsArray.length).toBeGreaterThanOrEqual(2);
 
     const allegroDirection = directionsArray.find(
@@ -284,6 +286,7 @@ describe("Echigo-Jishi.musicxml Parser Test", () => {
 
     const notesArray = getNotesFromContent(measure1.content);
     expect(notesArray).toBeDefined();
+    expect(measure1.notes?.length).toBe(notesArray.length);
     expect(notesArray).toHaveLength(4);
     const note1 = notesArray[0];
     expect(note1?.pitch?.step).toBe("A");
@@ -304,6 +307,7 @@ describe("Echigo-Jishi.musicxml Parser Test", () => {
     expect(measure11).toBeDefined();
     if (!measure11) return;
     const notesInMeasure11 = getNotesFromContent(measure11.content);
+    expect(measure11.notes?.length).toBe(notesInMeasure11.length);
     const noteWithLyric = notesInMeasure11.find(
       (n) => n.lyrics && n.lyrics.length > 0,
     );

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -119,6 +119,7 @@ describe("MusicXML Parser", () => {
     expect(attributesArray).toBeDefined();
     expect(attributesArray).toHaveLength(1);
     const attributes = attributesArray[0];
+    expect(measure.attributesElements?.length).toBe(attributesArray.length);
     expect(attributes).toBeDefined();
     if (!attributes) return;
 
@@ -139,6 +140,7 @@ describe("MusicXML Parser", () => {
     // Check notes using helper
     const notesArray = getNotesFromContent(measure.content);
     expect(notesArray).toHaveLength(4);
+    expect(measure.notes?.length).toBe(notesArray.length);
 
     const note1 = notesArray[0];
     expect(note1.pitch?.step).toBe("C");

--- a/tests/timeAdjustments.test.ts
+++ b/tests/timeAdjustments.test.ts
@@ -5,8 +5,7 @@ import {
   mapForwardElement,
   mapMeasureElement,
 } from "../src/parser/mappers";
-import type { Backup, Forward, Note } from "../src/types";
-import { NoteSchema } from "../src/schemas";
+import type { Backup, Forward } from "../src/types";
 
 function createElement(xml: string): Element {
   const dom = new JSDOM(xml, { contentType: "application/xml" });
@@ -50,28 +49,9 @@ describe("Backup and Forward mapping", () => {
     const el = createElement(measureXml);
     const measure = mapMeasureElement(el);
     expect(measure.content).toBeDefined();
-    const notes = measure.content?.filter((c): c is Note => {
-      if (typeof c === "object" && c !== null && "_type" in c) {
-        const currentType = (c as { _type: string })._type;
-        return currentType === "note" && NoteSchema.safeParse(c).success;
-      }
-      return false;
-    });
-    const backups = measure.content?.filter((c): c is Backup => {
-      if (typeof c === "object" && c !== null && "_type" in c) {
-        return (c as { _type: string })._type === "backup";
-      }
-      return false;
-    });
-    const forwards = measure.content?.filter((c): c is Forward => {
-      if (typeof c === "object" && c !== null && "_type" in c) {
-        return (c as { _type: string })._type === "forward";
-      }
-      return false;
-    });
-    expect(notes?.length).toBe(3);
-    expect(backups?.length).toBe(1);
-    expect(forwards?.length).toBe(1);
+    expect(measure.notes?.length).toBe(3);
+    expect(measure.backups?.length).toBe(1);
+    expect(measure.forwards?.length).toBe(1);
   });
 
   it("maintains order for multiple voices with backups and forwards", () => {
@@ -93,28 +73,12 @@ describe("Backup and Forward mapping", () => {
     expect((content[4] as Backup)._type).toBe("backup");
     expect((content[6] as Forward)._type).toBe("forward");
 
-    const backups = content.filter((c): c is Backup => {
-      if (typeof c === "object" && c !== null && "_type" in c) {
-        return (c as { _type: string })._type === "backup";
-      }
-      return false;
-    });
-    const forwards = content.filter((c): c is Forward => {
-      if (typeof c === "object" && c !== null && "_type" in c) {
-        return (c as { _type: string })._type === "forward";
-      }
-      return false;
-    });
+    const backups = measure.backups ?? [];
+    const forwards = measure.forwards ?? [];
     expect(backups.length).toBe(1);
     expect(forwards.length).toBe(1);
 
-    const notes = content.filter((c): c is Note => {
-      if (typeof c === "object" && c !== null && "_type" in c) {
-        const currentType = (c as { _type: string })._type;
-        return currentType === "note" && NoteSchema.safeParse(c).success;
-      }
-      return false;
-    });
+    const notes = measure.notes ?? [];
     const voice1 = notes.filter((n) => n.voice === "1");
     const voice2 = notes.filter((n) => n.voice === "2");
     expect(voice1).toHaveLength(4);


### PR DESCRIPTION
## Summary
- compute notes, directions, barlines and other element lists when mapping measures
- expose these readonly arrays in the measure schema
- adjust part schema to avoid huge type inference
- update tests to check the new arrays

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`